### PR TITLE
Fix eslint identifying browser global variables as errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import jseslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reacteslint from "eslint-plugin-react";
+import globals from "globals";
 
 let parseIgnoreList = [
   "**/node_modules/**/*",
@@ -20,6 +21,11 @@ let reactRecommendedConfig = {
   settings: {
     react: {
       version: "detect",
+    },
+  },
+  languageOptions: {
+    globals: {
+      ...globals.browser,
     },
   },
   rules: {


### PR DESCRIPTION
Currently eslint identifies browser global variables such as `document` as errors. This PR fixes this