### PR TITLE
86czwbkhq - Made clickable properties in the property overview list of the Agent dashboard

### DIFF
--- a/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
+++ b/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
@@ -5,6 +5,7 @@ import { useAppSelector, useAppDispatch } from "../../../../store";
 import {selectProperties, selectPropertiesLoading, selectPropertiesError, fetchAgentProperties } from "../state/agent-dashboard-slice";
 import { PropertyStatus } from "/app/shared/api-models/property/PropertyStatus";
 import { Property } from '/app/client/library-modules/domain-models/property/Property';
+import { PropertyWithListingData } from "../../../../library-modules/use-cases/property-listing/models/PropertyWithListingData";
 import { useNavigate } from "react-router";
 import { NavigationPath } from "../../../../navigation";
 
@@ -32,6 +33,13 @@ export function PropertyOverview({
   const handleViewAllClick = () => {
     navigate(NavigationPath.AgentProperties);
   };
+
+  // Property click handler to navigate to property details
+  const handlePropertyClick = (propertyId: string) => {
+    if (propertyId) {            
+        navigate(`/property-listing?propertyId=${propertyId}`);
+    }
+  }
 
   return (
     <CardWidget
@@ -67,7 +75,11 @@ export function PropertyOverview({
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {properties.map((property, index) => (
-                  <tr key={index} className="transition-colors hover:bg-gray-50">
+                  <tr key={index} className="transition-colors hover:bg-gray-50" 
+                      onClick={() => handlePropertyClick(property.propertyId)} role="button" 
+                      tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && handlePropertyClick(property.propertyId)} 
+                      aria-label={'View property details for property at ${property.streetnumber} ${property.streetname}'}
+                      >
                     <td className="px-6 py-4 text-sm">{`${property.streetnumber} ${property.streetname}`}</td>
                     <td className="px-6 py-4">
                       <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
@@ -75,8 +87,8 @@ export function PropertyOverview({
                         property.propertyStatus === PropertyStatus.DRAFT ? "bg-purple-100 text-purple-800" :
                         property.propertyStatus === PropertyStatus.LISTED ? "bg-blue-100 text-blue-800" :
                         property.propertyStatus === PropertyStatus.UNDER_MAINTENANCE ? "bg-yellow-100 text-yellow-800" :
-                        property.propertyStatus === PropertyStatus.VACANT ? "bg-red-100 text-red-800" :
-                        property.propertyStatus === PropertyStatus.OCCUPIED ? "bg-green-100 text-green-800" :
+                        property.propertyStatus === PropertyStatus.VACANT ? "bg-green-100 text-green-800" :
+                        property.propertyStatus === PropertyStatus.OCCUPIED ? "bg-red-100 text-red-800" :
                         "bg-grey-100 text-grey-800"
                       }`}>
                         {property.propertyStatus}


### PR DESCRIPTION
Made the properties in the property overview list of the Agent dashboard be clickable buttons now (routing to the correct properties). Also, swapped the colours of the property status VACANT (now green) & OCCUPIED (now red).

<img width="2784" height="1490" alt="Screenshot 2025-08-06 at 00 19 54" src="https://github.com/user-attachments/assets/505b2cca-cae1-4ec4-90d0-e5dff1dd8b76" />
