### PR TITLE
86czyr75e fix filter button on agent dashboard for properties

### DIFF
--- a/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
+++ b/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
@@ -47,38 +47,19 @@ export function PropertyOverview({
       rightElement={
         <Popover>
           <PopoverTrigger asChild>
-            <button 
-              className="flex items-center gap-2 px-3 py-2 border rounded-lg hover:bg-gray-50"
-              type="button"
-            >
+            <button className="flex items-center gap-2 px-3 py-2 border rounded-lg hover:bg-gray-50">
               <span>Filter {filterStatus && `(${filterStatus})`}</span>
-              <svg 
-                className="w-4 h-4" 
-                fill="none" 
-                stroke="currentColor" 
-                viewBox="0 0 24 24"
-              >
-                <path 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  strokeWidth={2} 
-                  d="M19 9l-7 7-7-7" 
-                />
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
           </PopoverTrigger>
-          <PopoverContent 
-            align="end" 
-            sideOffset={8}
-            className="w-48 p-1"
-          >
+          <PopoverContent align="end" sideOffset={8} className="w-48 p-1">
             <div className="space-y-1">
               <button
                 onClick={() => setFilterStatus(null)}
                 className={`w-full text-left px-3 py-2 text-sm rounded ${
-                  !filterStatus 
-                    ? 'bg-blue-50 text-blue-800' 
-                    : 'text-gray-700 hover:bg-gray-100'
+                  !filterStatus ? 'bg-blue-50 text-blue-800' : 'text-gray-700 hover:bg-gray-100'
                 }`}
               >
                 All Statuses
@@ -89,12 +70,10 @@ export function PropertyOverview({
                   onClick={() => setFilterStatus(status)}
                   className={`w-full text-left px-3 py-2 text-sm rounded ${
                     filterStatus === status
-                      ? `${
-                          status === PropertyStatus.OCCUPIED ? 'bg-red-50 text-red-800' :
-                          status === PropertyStatus.VACANT ? 'bg-green-50 text-green-800' :
-                          status === PropertyStatus.UNDER_MAINTENANCE ? 'bg-yellow-50 text-yellow-800' :
-                          'bg-blue-50 text-blue-800'
-                        }`
+                      ? status === PropertyStatus.OCCUPIED ? 'bg-red-50 text-red-800' :
+                        status === PropertyStatus.VACANT ? 'bg-green-50 text-green-800' :
+                        status === PropertyStatus.UNDER_MAINTENANCE ? 'bg-yellow-50 text-yellow-800' :
+                        'bg-blue-50 text-blue-800'
                       : 'text-gray-700 hover:bg-gray-100'
                   }`}
                 >
@@ -122,12 +101,16 @@ export function PropertyOverview({
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
-                {properties.map((property, index) => (
-                  <tr key={index} className="transition-colors hover:bg-gray-50"
-                      onClick={() => handlePropertyClick(property.propertyId)} role="button"
-                      tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && handlePropertyClick(property.propertyId)}
-                      aria-label={'View property details for property at ${property.streetnumber} ${property.streetname}'}
-                      >
+                {filteredProperties.map((property, index) => (
+                  <tr
+                    key={index}
+                    className="transition-colors hover:bg-gray-50"
+                    onClick={() => handlePropertyClick(property.propertyId)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => e.key === 'Enter' && handlePropertyClick(property.propertyId)}
+                    aria-label={`View property details for property at ${property.streetnumber} ${property.streetname}`}
+                  >
                     <td className="px-6 py-4 text-sm">{`${property.streetnumber} ${property.streetname}`}</td>
                     <td className="px-6 py-4">
                       <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
@@ -150,12 +133,11 @@ export function PropertyOverview({
           </div>
         )}
       </div>
-
-                           <div className="mt-4">
-          <ViewAllButton onClick={handleViewAllClick}>
-            View All Properties
-          </ViewAllButton>
-        </div>
+      <div className="mt-4">
+        <ViewAllButton onClick={handleViewAllClick}>
+          View All Properties
+        </ViewAllButton>
+      </div>
     </CardWidget>
   );
 }

--- a/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
+++ b/app/client/ui-modules/role-dashboard/agent-dashboard/components/PropertyOverview.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { Popover, PopoverTrigger, PopoverContent } from "../../../theming-shadcn/Popover";
 import { CardWidget } from "../../components/CardWidget";
 import { ViewAllButton } from "../../components/ViewAllButton";
 import { PropertyStatus } from "/app/shared/api-models/property/PropertyStatus";
@@ -19,6 +20,12 @@ export function PropertyOverview({
   error = null,
 }: PropertyOverviewProps): React.JSX.Element {
   const navigate = useNavigate();
+  const [filterStatus, setFilterStatus] = useState<PropertyStatus | null>(null);
+  // const [isFilterOpen, setIsFilterOpen] = useState(false);
+
+  const filteredProperties = filterStatus
+    ? properties.filter(property => property.propertyStatus === filterStatus)
+    : properties;
 
   // Handler for the button click
   const handleViewAllClick = () => {
@@ -38,14 +45,65 @@ export function PropertyOverview({
       value=""
       subtitle="Quick view of your managed properties"
       rightElement={
-        <button className="flex items-center gap-2 px-3 py-2 border rounded-lg hover:bg-gray-50"
-          type="button"
-        >
-          <span>Filter</span>
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button 
+              className="flex items-center gap-2 px-3 py-2 border rounded-lg hover:bg-gray-50"
+              type="button"
+            >
+              <span>Filter {filterStatus && `(${filterStatus})`}</span>
+              <svg 
+                className="w-4 h-4" 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M19 9l-7 7-7-7" 
+                />
+              </svg>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent 
+            align="end" 
+            sideOffset={8}
+            className="w-48 p-1"
+          >
+            <div className="space-y-1">
+              <button
+                onClick={() => setFilterStatus(null)}
+                className={`w-full text-left px-3 py-2 text-sm rounded ${
+                  !filterStatus 
+                    ? 'bg-blue-50 text-blue-800' 
+                    : 'text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                All Statuses
+              </button>
+              {Object.values(PropertyStatus).map((status) => (
+                <button
+                  key={status}
+                  onClick={() => setFilterStatus(status)}
+                  className={`w-full text-left px-3 py-2 text-sm rounded ${
+                    filterStatus === status
+                      ? `${
+                          status === PropertyStatus.OCCUPIED ? 'bg-red-50 text-red-800' :
+                          status === PropertyStatus.VACANT ? 'bg-green-50 text-green-800' :
+                          status === PropertyStatus.UNDER_MAINTENANCE ? 'bg-yellow-50 text-yellow-800' :
+                          'bg-blue-50 text-blue-800'
+                        }`
+                      : 'text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  {status}
+                </button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
       }
     >
       <div className="mt-2">


### PR DESCRIPTION
- Fixed the filter button on the agent dashboard to actually filter the properties list. 
- Just added a status of filtering to the PropertyOverview page for agent, and different filtering options based on the pre-exisiting filtering options. 
- Uses the Shadcn popover component as the popup when clicking the filter button (i.e. adheres to design)

<img width="724" height="483" alt="Screenshot 2025-08-13 at 10 53 10" src="https://github.com/user-attachments/assets/aee38dc2-d213-45bc-8cc7-eeed60c6c40f" />
