### PR TITLE
86d08m6tm fix persistant booked inspection bug

### DIFF
--- a/app/client/library-modules/apis/property-listing/listing-api.ts
+++ b/app/client/library-modules/apis/property-listing/listing-api.ts
@@ -68,7 +68,7 @@ export async function apiUpdatePropertyListingImages(
 }
 
 export async function apiInsertPropertyListingInspections(
-  propertyListingInspections: { start_time: Date; end_time: Date }[]
+  propertyListingInspections: { start_time: Date; end_time: Date; tenant_ids: string[] }[]
 ): Promise<string[]> {
   const ids = await Meteor.callAsync(
     MeteorMethodIdentifier.INSERT_PROPERTY_LISTING_INSPECTION,

--- a/app/client/library-modules/domain-models/property-listing/Listing.ts
+++ b/app/client/library-modules/domain-models/property-listing/Listing.ts
@@ -5,5 +5,6 @@ export type Listing = {
   propertyListingInspections: {
     start_time: Date;
     end_time: Date;
+    tenant_ids: string[];
   }[];
 }

--- a/app/client/library-modules/domain-models/property-listing/repositories/listing-repository.ts
+++ b/app/client/library-modules/domain-models/property-listing/repositories/listing-repository.ts
@@ -32,7 +32,7 @@ export async function insertPropertyListing(
 }
 
 export async function insertPropertyListingInspections(
-  propertyListingInspections: { start_time: Date; end_time: Date }[]
+  propertyListingInspections: { start_time: Date; end_time: Date; tenant_ids: string[]; }[]
 ): Promise<string[]> {
   return apiInsertPropertyListingInspections(propertyListingInspections);
 }

--- a/app/client/library-modules/use-cases/property-listing/models/PropertyWithListingData.ts
+++ b/app/client/library-modules/use-cases/property-listing/models/PropertyWithListingData.ts
@@ -23,6 +23,8 @@ export type PropertyWithListingData = {
   locationLongitude: number;
   listing_status: string;
   propertyListingInspections: {
+    tenant_ids: any;
+    _id: any;
     start_time: Date;
     end_time: Date;
   }[];

--- a/app/client/library-modules/use-cases/property-listing/models/PropertyWithListingData.ts
+++ b/app/client/library-modules/use-cases/property-listing/models/PropertyWithListingData.ts
@@ -23,9 +23,9 @@ export type PropertyWithListingData = {
   locationLongitude: number;
   listing_status: string;
   propertyListingInspections: {
-    tenant_ids: any;
-    _id: any;
+    _id: string;
     start_time: Date;
     end_time: Date;
+    tenant_ids: string[];
   }[];
 }

--- a/app/client/ui-modules/property-form-agent/state/reducers/property-form-slice.ts
+++ b/app/client/ui-modules/property-form-agent/state/reducers/property-form-slice.ts
@@ -82,6 +82,7 @@ export const submitForm = createAsyncThunk(
       (propertyFormData.inspection_times ?? []).map((t) => ({
         start_time: t.start_time,
         end_time: t.end_time,
+        tenant_ids: [],
       }))
     );
 

--- a/app/client/ui-modules/property-listing-page/PropertyListingPage.tsx
+++ b/app/client/ui-modules/property-listing-page/PropertyListingPage.tsx
@@ -1,15 +1,24 @@
 import React, { useEffect, useState } from "react";
 import { PropertyFeatures } from "/app/client/ui-modules/common/property-components/PropertyFeatures";
 import { PropertySpecifics } from "/app/client/ui-modules/common/property-components/PropertySpecifics";
-import { PropertyStatusPillVariant, ListingSummary } from "./components/ListingSummary";
+import {
+  PropertyStatusPillVariant,
+  ListingSummary,
+} from "./components/ListingSummary";
 import { PropertyDescription } from "/app/client/ui-modules/common/property-components/PropertyDescription";
 import { LeftCircularArrowIcon } from "/app/client/ui-modules/theming/icons/LeftCircularArrowIcon";
 import { RightCircularArrowIcon } from "/app/client/ui-modules/theming/icons/RightCircularArrowIcon";
 import { ImageCarousel } from "../theming/components/ImageCarousel";
-import { InspectionBookingListUiState, PropertyInspections } from "./components/PropertyInspections";
+import {
+  InspectionBookingListUiState,
+  PropertyInspections,
+} from "./components/PropertyInspections";
 import { ApplyButton } from "/app/client/ui-modules/property-listing-page/components/ApplyButton";
 import { ContactAgentButton } from "/app/client/ui-modules/common/property-components/ContactAgentButton";
-import { ListingStatusPill, ListingStatusPillVariant } from "/app/client/ui-modules/property-listing-page/components/ListingStatusPill";
+import {
+  ListingStatusPill,
+  ListingStatusPillVariant,
+} from "/app/client/ui-modules/property-listing-page/components/ListingStatusPill";
 import { BackLink } from "../theming/components/BackLink";
 import { BackButtonIcon } from "/app/client/ui-modules/theming/icons/BackButtonIcon";
 import { twMerge } from "tailwind-merge";
@@ -19,6 +28,7 @@ import { TenantSelectionModal } from "/app/client/ui-modules/tenant-selection/Te
 import { useAppDispatch, useAppSelector } from "/app/client/store";
 import { useSelector } from "react-redux";
 import {
+  bookPropertyInspectionAsync,
   load,
   selectPropertyListingUiState,
   submitDraftListingAsync,
@@ -30,7 +40,10 @@ import EditDraftListingModal from "./components/EditDraftListingModal";
 import { EditDraftListingButton } from "./components/EditDraftListingButton";
 import { FormSchemaType } from "/app/client/ui-modules/property-form-agent/components/FormSchema";
 import { SubHeading } from "../theming/components/SubHeading";
-import { PropertyMap, PropertyMapUiState } from "/app/client/ui-modules/common/property-components/PropertyMap";
+import {
+  PropertyMap,
+  PropertyMapUiState,
+} from "/app/client/ui-modules/common/property-components/PropertyMap";
 import { NavigationPath } from "../../navigation";
 import { BACK_ROUTES, EntryPoint } from "../../navigation";
 import {
@@ -56,12 +69,18 @@ import { addBookedPropertyListingInspection } from "./state/reducers/property-li
 import { Role } from "/app/shared/user-role-identifier";
 import { CurrentUserState } from "../user-authentication/state/CurrentUserState";
 
-export function PropertyListingPage({ className = "" }: { className?: string }): React.JSX.Element {
+export function PropertyListingPage({
+  className = "",
+}: {
+  className?: string;
+}): React.JSX.Element {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const propertyId = searchParams.get("propertyId");
   const dispatch = useAppDispatch();
-  const state: PropertyListingPageUiState = useSelector(selectPropertyListingUiState);
+  const state: PropertyListingPageUiState = useSelector(
+    selectPropertyListingUiState
+  );
   const currentUser = useAppSelector((state) => state.currentUser.currentUser);
   const profileData = useAppSelector((state) => state.currentUser.profileData);
   const authUser = useAppSelector((state) => state.currentUser.authUser);
@@ -84,7 +103,11 @@ export function PropertyListingPage({ className = "" }: { className?: string }):
   }, [propertyId, authUser]);
 
   if (state.shouldShowLoadingState) {
-    return <ListingPageContentLoadingSkeleton className={twMerge("p-5", className)} />;
+    return (
+      <ListingPageContentLoadingSkeleton
+        className={twMerge("p-5", className)}
+      />
+    );
   } else {
     return (
       <>
@@ -108,13 +131,17 @@ export function PropertyListingPage({ className = "" }: { className?: string }):
           propertyPrice={state.propertyPrice}
           mapUiState={state.mapUiState}
           inspectionBookingUiStateList={state.inspectionBookingUiStateList}
-          bookedPropertyListingInspections={state.bookedPropertyListingInspections}
+          bookedPropertyListingInspections={
+            state.bookedPropertyListingInspections
+          }
           listingImageUrls={state.listingImageUrls}
           listingStatusText={state.listingStatusText}
           listingStatusPillVariant={state.listingStatusPillVariant}
           shouldDisplayListingStatus={state.shouldDisplayListingStatus}
           shouldDisplaySubmitDraftButton={state.shouldDisplaySubmitDraftButton}
-          shouldDisplayReviewTenantButton={state.shouldDisplayReviewTenantButton}
+          shouldDisplayReviewTenantButton={
+            state.shouldDisplayReviewTenantButton
+          }
           shouldDisplayEditListingButton={state.shouldDisplayEditListingButton}
           authUser={authUser}
           profileData={profileData}
@@ -129,6 +156,18 @@ export function PropertyListingPage({ className = "" }: { className?: string }):
           onBook={(index: number) => {
             console.log(`booking button ${index} pressed`);
             dispatch(addBookedPropertyListingInspection(index));
+            if (state.inspectionBookingUiStateList[index]) {
+              const inspectionId =
+                state.inspectionBookingUiStateList[index]._id; // make sure each item has `id`
+              if (inspectionId && currentUser?.userAccountId) {
+                dispatch(
+                  bookPropertyInspectionAsync({
+                    inspectionId,
+                    tenantId: currentUser.userAccountId,
+                  })
+                );
+              }
+            }
           }}
           onApply={async () => {
             console.log("Apply button clicked!");
@@ -136,12 +175,18 @@ export function PropertyListingPage({ className = "" }: { className?: string }):
             console.log("Profile data:", profileData);
 
             try {
-              const result = await dispatch(createTenantApplicationAsync()).unwrap();
+              const result = await dispatch(
+                createTenantApplicationAsync()
+              ).unwrap();
               console.log("Tenant application created successfully:", result);
               alert(result.message);
             } catch (error) {
               console.error("Failed to create tenant application:", error);
-              alert(error instanceof Error ? error.message : "Failed to submit application. Please try again.");
+              alert(
+                error instanceof Error
+                  ? error.message
+                  : "Failed to submit application. Please try again."
+              );
             }
           }}
           onContactAgent={() => console.log("contacting agent!")}
@@ -233,33 +278,63 @@ function ListingPageContent({
   const [isReviewTenantModalOpen, setIsReviewTenantModalOpen] = useState(false);
   const dispatch = useAppDispatch();
 
-  const tenantApplications = useAppSelector((state) => selectFilteredApplications(state, propertyId));
-  const isCreatingApplication = useAppSelector((state) => state.tenantSelection.isLoading);
+  const tenantApplications = useAppSelector((state) =>
+    selectFilteredApplications(state, propertyId)
+  );
+  const isCreatingApplication = useAppSelector(
+    (state) => state.tenantSelection.isLoading
+  );
 
-  const acceptedApplicantCount = useAppSelector((state) => selectAcceptedApplicantCountForProperty(state, propertyId));
-  const hasAcceptedApplications = useAppSelector((state) => selectHasAcceptedApplicationsForProperty(state, propertyId));
+  const acceptedApplicantCount = useAppSelector((state) =>
+    selectAcceptedApplicantCountForProperty(state, propertyId)
+  );
+  const hasAcceptedApplications = useAppSelector((state) =>
+    selectHasAcceptedApplicationsForProperty(state, propertyId)
+  );
 
   // Get current user's name for checking if they've already applied
-  const currentUserName = profileData ? `${profileData.firstName} ${profileData.lastName}` : undefined;
-  const hasCurrentUserApplied = useAppSelector((state) => selectHasCurrentUserApplied(state, propertyId, currentUserName));
+  const currentUserName = profileData
+    ? `${profileData.firstName} ${profileData.lastName}`
+    : undefined;
+  const hasCurrentUserApplied = useAppSelector((state) =>
+    selectHasCurrentUserApplied(state, propertyId, currentUserName)
+  );
 
   // Step 2 selectors for landlord approved applications
-  const hasLandlordApprovedApplications = useAppSelector((state) => selectHasLandlordApprovedApplicationsForProperty(state, propertyId));
-  const landlordApprovedApplicantCount = useAppSelector((state) => selectLandlordApprovedApplicantCountForProperty(state, propertyId));
+  const hasLandlordApprovedApplications = useAppSelector((state) =>
+    selectHasLandlordApprovedApplicationsForProperty(state, propertyId)
+  );
+  const landlordApprovedApplicantCount = useAppSelector((state) =>
+    selectLandlordApprovedApplicantCountForProperty(state, propertyId)
+  );
 
-  const hasBackgroundPassedApplications = useAppSelector((state) => selectHasBackgroundPassedApplicationsForProperty(state, propertyId));
-  const backgroundPassedApplicantCount = useAppSelector((state) => selectBackgroundPassedApplicantCountForProperty(state, propertyId));
+  const hasBackgroundPassedApplications = useAppSelector((state) =>
+    selectHasBackgroundPassedApplicationsForProperty(state, propertyId)
+  );
+  const backgroundPassedApplicantCount = useAppSelector((state) =>
+    selectBackgroundPassedApplicantCountForProperty(state, propertyId)
+  );
 
-  const shouldShowSendToLandlordButton = (hasAcceptedApplications || hasBackgroundPassedApplications) && authUser?.role === Role.AGENT;
-  const shouldShowSendToAgentButton = hasLandlordApprovedApplications && authUser?.role === Role.LANDLORD;
+  const shouldShowSendToLandlordButton =
+    (hasAcceptedApplications || hasBackgroundPassedApplications) &&
+    authUser?.role === Role.AGENT;
+  const shouldShowSendToAgentButton =
+    hasLandlordApprovedApplications && authUser?.role === Role.LANDLORD;
 
-  const hasFinalApprovedApplications = useAppSelector((state) => selectHasFinalApprovedApplicationForProperty(state, propertyId));
-  const finalApprovedApplicantCount = useAppSelector((state) => selectFinalApprovedApplicantCountForProperty(state, propertyId));
-  const shouldShowSendFinalApprovedToAgentButton = hasFinalApprovedApplications && authUser?.role === Role.LANDLORD;
+  const hasFinalApprovedApplications = useAppSelector((state) =>
+    selectHasFinalApprovedApplicationForProperty(state, propertyId)
+  );
+  const finalApprovedApplicantCount = useAppSelector((state) =>
+    selectFinalApprovedApplicantCountForProperty(state, propertyId)
+  );
+  const shouldShowSendFinalApprovedToAgentButton =
+    hasFinalApprovedApplications && authUser?.role === Role.LANDLORD;
 
   const handleAccept = async (applicationId: string) => {
     try {
-      await dispatch(intentAcceptApplicationAsync({ propertyId, applicationId })).unwrap();
+      await dispatch(
+        intentAcceptApplicationAsync({ propertyId, applicationId })
+      ).unwrap();
     } catch (error) {
       console.error("Failed to accept application:", error);
     }
@@ -267,7 +342,9 @@ function ListingPageContent({
 
   const handleReject = async (applicationId: string) => {
     try {
-      await dispatch(intentRejectApplicationAsync({ propertyId, applicationId })).unwrap();
+      await dispatch(
+        intentRejectApplicationAsync({ propertyId, applicationId })
+      ).unwrap();
     } catch (error) {
       console.error("Failed to reject application:", error);
     }
@@ -296,7 +373,10 @@ function ListingPageContent({
       await dispatch(sendFinalApprovedApplicationToAgentAsync()).unwrap();
       console.log("Successfully sent final approved application to agent");
     } catch (error) {
-      console.error("Failed to send final approved application to agent:", error);
+      console.error(
+        "Failed to send final approved application to agent:",
+        error
+      );
     }
   };
 
@@ -376,7 +456,9 @@ function ListingPageContent({
           onSendToAgent={handleSendToAgent}
           onSendFinalApprovedToAgent={handleSendFinalApprovedToAgent}
           shouldShowSendToAgentButton={shouldShowSendToAgentButton}
-          shouldShowSendFinalApprovedToAgentButton={shouldShowSendFinalApprovedToAgentButton}
+          shouldShowSendFinalApprovedToAgentButton={
+            shouldShowSendFinalApprovedToAgentButton
+          }
           landlordApprovedApplicantCount={landlordApprovedApplicantCount}
           finalApprovedApplicantCount={finalApprovedApplicantCount}
           tenantApplications={tenantApplications}
@@ -386,7 +468,11 @@ function ListingPageContent({
   );
 }
 
-function ListingPageContentLoadingSkeleton({ className = "" }: { className?: string }): React.JSX.Element {
+function ListingPageContentLoadingSkeleton({
+  className = "",
+}: {
+  className?: string;
+}): React.JSX.Element {
   return <p className={className}>Loading...</p>;
 }
 
@@ -405,8 +491,18 @@ function TopBar({
 }): React.JSX.Element {
   return (
     <div className={twMerge("flex items-start", className)}>
-      <BackLink label="Back to Properties" backButtonIcon={<BackButtonIcon />} onClick={onBack} className="mr-auto" />
-      {shouldDisplayListingStatus && <ListingStatusPill text={listingStatusText} variant={listingStatusPillVariant} />}
+      <BackLink
+        label="Back to Properties"
+        backButtonIcon={<BackButtonIcon />}
+        onClick={onBack}
+        className="mr-auto"
+      />
+      {shouldDisplayListingStatus && (
+        <ListingStatusPill
+          text={listingStatusText}
+          variant={listingStatusPillVariant}
+        />
+      )}
     </div>
   );
 }
@@ -488,7 +584,13 @@ function ListingHero({
           className="w-full mb-8"
         />
         <div className="flex">
-          <ApplyButton onClick={onApply} isLoading={isApplying} userRole={userRole} hasApplied={hasApplied} className="mr-4" />
+          <ApplyButton
+            onClick={onApply}
+            isLoading={isApplying}
+            userRole={userRole}
+            hasApplied={hasApplied}
+            className="mr-4"
+          />
           <ContactAgentButton propertyId={propertyId} />
         </div>
       </div>
@@ -518,7 +620,10 @@ function ListingDetails({
   return (
     <div className={twMerge("flex gap-7", className)}>
       <div className="flex-1 flex flex-col">
-        <PropertyDescription description={propertyDescription} className="mb-4" />
+        <PropertyDescription
+          description={propertyDescription}
+          className="mb-4"
+        />
         <PropertyInspections
           bookingUiStateList={inspectionBookingUiStateList}
           onBook={onBook}
@@ -553,22 +658,36 @@ function BottomBar({
   className?: string;
 }): React.JSX.Element {
   return (
-    <div className={twMerge("flex justify-between items-center gap-2", className)}>
+    <div
+      className={twMerge("flex justify-between items-center gap-2", className)}
+    >
       {/* Left side - Review Tenant Button */}
-      <div className="flex">{shouldDisplayReviewTenantButton && <ReviewTenantButton onClick={onReviewTenant} />}</div>
+      <div className="flex">
+        {shouldDisplayReviewTenantButton && (
+          <ReviewTenantButton onClick={onReviewTenant} />
+        )}
+      </div>
 
       <div className="flex">
         {shouldDisplayEditListingButton && <ListingModalEditor />}
-        {shouldDisplaySubmitDraftButton && <SubmitDraftListingButton onClick={onSubmitDraftListing} />}
+        {shouldDisplaySubmitDraftButton && (
+          <SubmitDraftListingButton onClick={onSubmitDraftListing} />
+        )}
       </div>
     </div>
   );
 }
 
-function ListingModalEditor({ className = "" }: { className?: string }): React.JSX.Element {
+function ListingModalEditor({
+  className = "",
+}: {
+  className?: string;
+}): React.JSX.Element {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const toggleModal = () => setIsModalOpen(!isModalOpen);
-  const state: PropertyListingPageUiState = useSelector(selectPropertyListingUiState);
+  const state: PropertyListingPageUiState = useSelector(
+    selectPropertyListingUiState
+  );
 
   const listingInfo: FormSchemaType = {
     agent: state.agentId,

--- a/app/client/ui-modules/property-listing-page/components/PropertyInspections.tsx
+++ b/app/client/ui-modules/property-listing-page/components/PropertyInspections.tsx
@@ -13,7 +13,7 @@ export type InspectionBookingListUiState = {
   date: string;
   startingTime: string;
   endingTime: string;
-  isBooked?: boolean;
+   isBooked?: boolean;
 };
 
 export function PropertyInspections({

--- a/app/client/ui-modules/property-listing-page/components/PropertyInspections.tsx
+++ b/app/client/ui-modules/property-listing-page/components/PropertyInspections.tsx
@@ -10,10 +10,12 @@ import { SubHeading } from "/app/client/ui-modules/theming/components/SubHeading
 import { Role } from "/app/shared/user-role-identifier";
 
 export type InspectionBookingListUiState = {
+  _id: string;
   date: string;
   startingTime: string;
   endingTime: string;
-   isBooked?: boolean;
+  tenant_ids: string[]; // array of tenant ids who have booked this inspection
+  isBooked?: boolean;
 };
 
 export function PropertyInspections({

--- a/app/client/ui-modules/property-listing-page/state/reducers/property-listing-slice.ts
+++ b/app/client/ui-modules/property-listing-page/state/reducers/property-listing-slice.ts
@@ -11,8 +11,8 @@ import {
   getFormattedDateStringFromDate,
   getFormattedTimeStringFromDate,
 } from "/app/client/library-modules/utils/date-utils";
-import { bookPropertyInspectionAsync } from "/app/server/methods/property-listing/listing-methods";
 
+import { PropertyListingInspectionDocument } from "/app/server/database/property-listing/models/PropertyListingInspectionDocument";
 const initialState: PropertyListingPageUiState = {
   propertyId: "",
   propertyLandlordId: "",
@@ -241,6 +241,22 @@ export const load = createAsyncThunk(
   }
 );
 
-
+export const bookPropertyInspectionAsync = createAsyncThunk(
+  "propertyListing/bookPropertyInspection",
+  async ({
+    inspectionId,
+    tenantId,
+  }: {
+    inspectionId: string;
+    tenantId: string;
+  }): Promise<PropertyListingInspectionDocument> => {
+    const updatedInspection: PropertyListingInspectionDocument = await Meteor.callAsync(
+      "inspection.addTenant",
+      inspectionId,
+      tenantId
+    );
+    return updatedInspection;
+  }
+);
 export const selectPropertyListingUiState = (state: RootState) =>
   state.propertyListing;

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/components/PropertyInspections.tsx
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/components/PropertyInspections.tsx
@@ -9,9 +9,11 @@ import { twMerge } from "tailwind-merge";
 import { SubHeading } from "/app/client/ui-modules/theming/components/SubHeading";
 
 export type InspectionBookingListUiState = {
+  _id : string;
   date: string;
   startingTime: string;
   endingTime: string;
+  tenant_ids: string[]; // array of tenant ids who have booked this inspection
 };
 
 export function PropertyInspections({

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/components/PropertyInspections.tsx
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/components/PropertyInspections.tsx
@@ -9,7 +9,7 @@ import { twMerge } from "tailwind-merge";
 import { SubHeading } from "/app/client/ui-modules/theming/components/SubHeading";
 
 export type InspectionBookingListUiState = {
-  _id : string;
+  _id: string;
   date: string;
   startingTime: string;
   endingTime: string;
@@ -22,7 +22,7 @@ export function PropertyInspections({
   className = "",
 }: {
   bookingUiStateList: InspectionBookingListUiState[];
-  onBook: (index: number) => void;
+  onBook: (inspectionId: string) => void;
   className?: string;
 }): React.JSX.Element {
   return (
@@ -42,7 +42,7 @@ function InspectionBookingList({
   className,
 }: {
   bookingUiStateList: InspectionBookingListUiState[];
-  onBook: (index: number) => void;
+  onBook: (inspectionId: string) => void; // <-- FIXED
   className?: string;
 }): React.JSX.Element {
   return (
@@ -54,7 +54,7 @@ function InspectionBookingList({
     >
       {bookingUiStateList.map((state, i) => (
         <BookingEntry
-          key={`${state.date}${state.startingTime}`}
+          key={state._id}
           bookingState={state}
           shouldDisplayDivider={i != 0}
           index={i}
@@ -75,7 +75,7 @@ function BookingEntry({
   bookingState: InspectionBookingListUiState;
   shouldDisplayDivider: boolean;
   index: number;
-  onBook: (index: number) => void;
+  onBook: (inspectionId: string) => void; // <-- FIXED
   className?: string;
 }): React.JSX.Element {
   return (
@@ -90,7 +90,10 @@ function BookingEntry({
           className="mr-auto"
         />
         <CalendarIcon className="w-[22px] h-[20px] mr-6" />
-        <BookingButton index={index} onClick={onBook} />
+        <BookingButton
+          inspectionId={bookingState._id} // <-- pass string id
+          onClick={() => onBook(bookingState._id)}
+        />
       </div>
     </div>
   );
@@ -116,20 +119,18 @@ function BookingDateTime({
 }
 
 function BookingButton({
-  index,
+  inspectionId,
   onClick,
   className = "",
 }: {
-  index: number;
-  onClick: (index: number) => void;
+  inspectionId: string;
+  onClick: (inspectionId: string) => void; // correct type
   className?: string;
 }): React.JSX.Element {
   return (
     <ThemedButton
       variant={ThemedButtonVariant.TERTIARY}
-      onClick={() => {
-        onClick(index);
-      }}
+      onClick={() => onClick(inspectionId)} // call with id
       className={twMerge("w-[117px] h-[36px]", className)}
     >
       Book

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/pages/TenantProperty.tsx
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/pages/TenantProperty.tsx
@@ -30,7 +30,6 @@ import { SubHeading } from "../../../theming/components/SubHeading";
 import { PropertyMap, PropertyMapUiState } from "../../../common/property-components/PropertyMap";
 import { fetchAgentWithProfile } from '../state/reducers/tenant-property-slice';
 import { AgentDetails } from '../components/AgentDetails';
-import { current } from "@reduxjs/toolkit";
 
 export function TenantProperty({
   className = "",
@@ -102,8 +101,8 @@ export function TenantProperty({
           onBack={() => {
             console.log("back button pressed");
           }}
-          onBook={(index: number) => {
-            console.log(`booking button ${index} pressed`);
+          onBook={(inspectionId: string) => {
+            console.log(`booking button ${inspectionId} pressed`);
           }}
           onApply={() => {
             console.log("applied!");
@@ -180,7 +179,7 @@ function PropertyPageContent({
   propertyLandlordId: string;
   propertyId: string;
   onBack: () => void;
-  onBook: (index: number) => void;
+  onBook: (inspectionId: string) => void; // <-- FIXED
   onApply: () => void;
   onContactAgent: () => void;
   onSubmitDraftListing: () => void;
@@ -344,7 +343,7 @@ function PropertyDetails({
   propertyDescription: string;
   mapUiState: PropertyMapUiState;
   inspectionBookingUiStateList: InspectionBookingListUiState[];
-  onBook: (index: number) => void;
+  onBook: (inspectionId: string) => void; // <-- change to string
   propertyFeatures: string[];
   propertyId: string;
   className?: string;

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/state/reducers/tenant-property-slice.ts
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/state/reducers/tenant-property-slice.ts
@@ -128,10 +128,6 @@ export const fetchAgentWithProfile = createAsyncThunk(
       if (!property.agentId) {
         throw new Error('No agent assigned to this property');
       }
-      // console.log('Property agent ID:', property.agentId);
-      // const user = await getUserAccountById(property.agentId);
-      // console.log('Found user account for agent:', user);
-
       // Debug log for agent ID
       console.log('Fetching agent with ID:', property.agentId);
 
@@ -193,9 +189,11 @@ export const tenantPropertySlice = createSlice({
       }
       state.inspectionBookingUiStateList = action.payload.propertyListingInspections.map(
         (inspection) => ({
+          _id: inspection._id,
           date: getFormattedDateStringFromDate(inspection.start_time),
           startingTime: getFormattedTimeStringFromDate(inspection.start_time),
           endingTime: getFormattedTimeStringFromDate(inspection.end_time),
+          tenant_ids: inspection.tenant_ids
         })
       );
       state.listingImageUrls = action.payload.image_urls;

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/state/reducers/tenant-property-slice.ts
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/state/reducers/tenant-property-slice.ts
@@ -43,9 +43,11 @@ interface TenantPropertyState {
     markerLongitude: number;
   };
   inspectionBookingUiStateList: {
+    _id: string;
     date: string;
     startingTime: string;
     endingTime: string;
+    tenant_ids: string[];
   }[];
   listingImageUrls: string[];
   listingStatusText: string;

--- a/app/server/database/property-listing/models/PropertyListingInspectionDocument.ts
+++ b/app/server/database/property-listing/models/PropertyListingInspectionDocument.ts
@@ -1,5 +1,6 @@
 export type PropertyListingInspectionDocument = {
     _id: string;
+    tenant_ids: string[]; // array of tenant ids who have booked this inspection
     starttime: Date;
     endtime: Date;
   }

--- a/app/server/main.ts
+++ b/app/server/main.ts
@@ -9,16 +9,16 @@ import "./methods/user-documents/lease-agreement-methods";
 import "./methods/tenant-application/tenant-application-method";
 
 import {
-	PropertyCollection,
-	PropertyCoordinatesCollection,
-	PropertyFeatureCollection,
-	PropertyPriceCollection,
-	PropertyStatusCollection,
+  PropertyCollection,
+  PropertyCoordinatesCollection,
+  PropertyFeatureCollection,
+  PropertyPriceCollection,
+  PropertyStatusCollection,
 } from "./database/property/property-collections";
 import {
-	PropertyListingInspectionCollection,
-	ListingCollection,
-	ListingStatusCollection,
+  PropertyListingInspectionCollection,
+  ListingCollection,
+  ListingStatusCollection,
 } from "/app/server/database/property-listing/listing-collections";
 import "/app/server/methods/property-status/property-status-methods";
 import "/app/server/methods/property-price/property-price-methods";
@@ -28,10 +28,12 @@ import "./methods/user/user-account-methods";
 import "./methods/user/role-methods/agent-methods";
 import "./methods/user/role-methods/tenant-methods";
 import "./methods/user/role-methods/landlord-methods";
+import "./methods/property-listing/listing-methods";
+import "./methods/property-listing/listing-methods";
 import { TaskCollection } from "/app/server/database/task/task-collections";
 import {
-	AgentCollection,
-	UserAccountCollection,
+  AgentCollection,
+  UserAccountCollection,
 } from "/app/server/database/user/user-collections";
 import { TenantApplicationCollection } from "./database/tenant/collections/TenantApplicationCollection";
 import { TenantCollection } from "./database/user/user-collections";
@@ -42,8 +44,8 @@ import { ApiAgent } from "../shared/api-models/user/api-roles/ApiAgent";
 import { ApiTenant } from "../shared/api-models/user/api-roles/ApiTenant";
 import { ApiLandlord } from "../shared/api-models/user/api-roles/ApiLandlord";
 import {
-	LandlordCollection,
-	ProfileCollection,
+  LandlordCollection,
+  ProfileCollection,
 } from "./database/user/user-collections";
 import { PropertyStatus } from "../shared/api-models/property/PropertyStatus";
 import "/app/server/methods/property/property-features/property-features-methods";
@@ -51,799 +53,802 @@ import { ListingStatus } from "../shared/api-models/property-listing/ListingStat
 import { PropertyDocument } from "./database/property/models/PropertyDocument";
 import { LeaseAgreementCollection } from "./database/user-documents/user-documents-collections";
 import { TaskPriority } from "../shared/task-priority-identifier";
-
 let globalAgent: ApiAgent;
 let globalTenant: ApiTenant;
 let globalLandlord: ApiLandlord;
 
 Meteor.startup(async () => {
-	await removeTenantApplicationsData();
+  await removeTenantApplicationsData();
 
-	await removeAllCollections();
-	// await tempSeedPropertyStatusData();
-	await permSeedListingStatusData();
-	await tempSeedUserAndRoleData();
-	await permSeedPropertyFeaturesData();
-	// await tempSeedPropertyData();
-	await tempSeedTaskData();
-	await tempSeedProfileData();
-	await tempSeedUserAndRoleData();
-	await tempSeedTaskData();
-	await seedPropertyCoordinatesForTempProperties();
-	await seedListedProperties(globalAgent, globalLandlord, globalTenant);
-	await seedLeaseAgreements(globalAgent);
+  await removeAllCollections();
+  // await tempSeedPropertyStatusData();
+  await permSeedListingStatusData();
+  await tempSeedUserAndRoleData();
+  await permSeedPropertyFeaturesData();
+  // await tempSeedPropertyData();
+  await tempSeedTaskData();
+  await tempSeedProfileData();
+  await tempSeedUserAndRoleData();
+  await tempSeedTaskData();
+  await seedPropertyCoordinatesForTempProperties();
+  await seedListedProperties(globalAgent, globalLandlord, globalTenant);
+  await seedLeaseAgreements(globalAgent);
 });
 
 async function tempSeedUserAndRoleData(): Promise<void> {
-	const seedUsers = [
-		{
-			email: "amandaapplebe@gmail.com",
-			password: "password123",
-			firstName: "Amanda",
-			lastName: "Applebe",
-			accountType: Role.AGENT,
-			agentCode: "AGENT123",
-		},
-		{
-			email: "toddtoolgate@gmail.com",
-			password: "password123",
-			firstName: "Todd",
-			lastName: "Toolgate",
-			accountType: Role.TENANT,
-		},
-		{
-			email: "lewislad@gmail.com",
-			password: "password123",
-			firstName: "Lewis",
-			lastName: "Lad",
-			accountType: Role.LANDLORD,
-		},
-	];
+  const seedUsers = [
+    {
+      email: "amandaapplebe@gmail.com",
+      password: "password123",
+      firstName: "Amanda",
+      lastName: "Applebe",
+      accountType: Role.AGENT,
+      agentCode: "AGENT123",
+    },
+    {
+      email: "toddtoolgate@gmail.com",
+      password: "password123",
+      firstName: "Todd",
+      lastName: "Toolgate",
+      accountType: Role.TENANT,
+    },
+    {
+      email: "lewislad@gmail.com",
+      password: "password123",
+      firstName: "Lewis",
+      lastName: "Lad",
+      accountType: Role.LANDLORD,
+    },
+  ];
 
-	for (const user of seedUsers) {
-		const existing = await Meteor.users.findOneAsync({
-			"emails.address": user.email,
-		});
-		if (existing) {
-			console.log(`[Seed] Skipped existing user: ${user.email}`);
-			const dto = await Meteor.callAsync(
-				user.accountType === Role.AGENT
-					? MeteorMethodIdentifier.AGENT_GET
-					: user.accountType === Role.TENANT
-						? MeteorMethodIdentifier.TENANT_GET
-						: MeteorMethodIdentifier.LANDLORD_GET,
-				existing._id
-			);
+  for (const user of seedUsers) {
+    const existing = await Meteor.users.findOneAsync({
+      "emails.address": user.email,
+    });
+    if (existing) {
+      console.log(`[Seed] Skipped existing user: ${user.email}`);
+      const dto = await Meteor.callAsync(
+        user.accountType === Role.AGENT
+          ? MeteorMethodIdentifier.AGENT_GET
+          : user.accountType === Role.TENANT
+            ? MeteorMethodIdentifier.TENANT_GET
+            : MeteorMethodIdentifier.LANDLORD_GET,
+        existing._id
+      );
 
-			if (user.accountType === Role.AGENT) globalAgent = dto;
-			if (user.accountType === Role.TENANT) globalTenant = dto;
-			if (user.accountType === Role.LANDLORD) globalLandlord = dto;
-			continue;
-		}
+      if (user.accountType === Role.AGENT) globalAgent = dto;
+      if (user.accountType === Role.TENANT) globalTenant = dto;
+      if (user.accountType === Role.LANDLORD) globalLandlord = dto;
+      continue;
+    }
 
-		try {
-			const { userAccountId } = await Meteor.callAsync(
-				MeteorMethodIdentifier.USER_REGISTER,
-				user
-			);
+    try {
+      const { userAccountId } = await Meteor.callAsync(
+        MeteorMethodIdentifier.USER_REGISTER,
+        user
+      );
 
-			const dto = await Meteor.callAsync(
-				user.accountType === Role.AGENT
-					? MeteorMethodIdentifier.AGENT_GET
-					: user.accountType === Role.TENANT
-						? MeteorMethodIdentifier.TENANT_GET
-						: MeteorMethodIdentifier.LANDLORD_GET,
-				userAccountId
-			);
+      const dto = await Meteor.callAsync(
+        user.accountType === Role.AGENT
+          ? MeteorMethodIdentifier.AGENT_GET
+          : user.accountType === Role.TENANT
+            ? MeteorMethodIdentifier.TENANT_GET
+            : MeteorMethodIdentifier.LANDLORD_GET,
+        userAccountId
+      );
 
-			if (user.accountType === Role.AGENT) globalAgent = dto;
-			if (user.accountType === Role.TENANT) globalTenant = dto;
-			if (user.accountType === Role.LANDLORD) globalLandlord = dto;
+      if (user.accountType === Role.AGENT) globalAgent = dto;
+      if (user.accountType === Role.TENANT) globalTenant = dto;
+      if (user.accountType === Role.LANDLORD) globalLandlord = dto;
 
-			console.log(`[Seed] Created user: ${user.email}`);
-		} catch (err) {
-			console.error(`[Seed] Failed to create user: ${user.email}`, err);
-		}
-	}
+      console.log(`[Seed] Created user: ${user.email}`);
+    } catch (err) {
+      console.error(`[Seed] Failed to create user: ${user.email}`, err);
+    }
+  }
 }
 
 async function seedPropertyCoordinatesForTempProperties(): Promise<void> {
-	const coordinates = [
-		{ _id: "1", latitude: -37.8136, longitude: 144.9631 }, // Melbourne
-		{ _id: "2", latitude: -33.8688, longitude: 151.2093 }, // Sydney
-		{ _id: "3", latitude: -27.4698, longitude: 153.0251 }, // Brisbane
-		{ _id: "4", latitude: -37.8761, longitude: 145.1643 }, // Glen waverley
-		{ _id: "5", latitude: -34.9285, longitude: 138.6007 }, // Adelaide
-		{ _id: "6", latitude: -31.9505, longitude: 115.8605 }, // Perth
-		{ _id: "7", latitude: -35.2809, longitude: 149.13 }, // Canberra
-		{ _id: "8", latitude: -12.4634, longitude: 130.8456 }, // Darwin
-		{ _id: "9", latitude: -33.8688, longitude: 151.2093 }, // Sydney
-		{ _id: "10", latitude: -37.892, longitude: 145.178 }, // Wheelers Hill
-		{ _id: "11", latitude: -38.0051, longitude: 145.1163 }, // Braeside
-		{ _id: "12", latitude: -37.9572, longitude: 145.0903 }, // Clarinda
-		{ _id: "13", latitude: -37.9863, longitude: 145.1274 }, // Dingley Village
-		{ _id: "14", latitude: -37.915, longitude: 145.1287 }, // Clayton
-	];
+  const coordinates = [
+    { _id: "1", latitude: -37.8136, longitude: 144.9631 }, // Melbourne
+    { _id: "2", latitude: -33.8688, longitude: 151.2093 }, // Sydney
+    { _id: "3", latitude: -27.4698, longitude: 153.0251 }, // Brisbane
+    { _id: "4", latitude: -37.8761, longitude: 145.1643 }, // Glen waverley
+    { _id: "5", latitude: -34.9285, longitude: 138.6007 }, // Adelaide
+    { _id: "6", latitude: -31.9505, longitude: 115.8605 }, // Perth
+    { _id: "7", latitude: -35.2809, longitude: 149.13 }, // Canberra
+    { _id: "8", latitude: -12.4634, longitude: 130.8456 }, // Darwin
+    { _id: "9", latitude: -33.8688, longitude: 151.2093 }, // Sydney
+    { _id: "10", latitude: -37.892, longitude: 145.178 }, // Wheelers Hill
+    { _id: "11", latitude: -38.0051, longitude: 145.1163 }, // Braeside
+    { _id: "12", latitude: -37.9572, longitude: 145.0903 }, // Clarinda
+    { _id: "13", latitude: -37.9863, longitude: 145.1274 }, // Dingley Village
+    { _id: "14", latitude: -37.915, longitude: 145.1287 }, // Clayton
+  ];
 
-	for (const coord of coordinates) {
-		const existing = await PropertyCoordinatesCollection.findOneAsync({
-			_id: coord._id,
-		});
-		if (!existing) {
-			await PropertyCoordinatesCollection.insertAsync(coord);
-			console.log(`[Seed] Inserted coordinate for property ID ${coord._id}`);
-		}
-	}
+  for (const coord of coordinates) {
+    const existing = await PropertyCoordinatesCollection.findOneAsync({
+      _id: coord._id,
+    });
+    if (!existing) {
+      await PropertyCoordinatesCollection.insertAsync(coord);
+      console.log(`[Seed] Inserted coordinate for property ID ${coord._id}`);
+    }
+  }
 }
 
 async function tempSeedProfileData(): Promise<void> {
-	if ((await ProfileCollection.find().countAsync()) === 0) {
-		ProfileCollection.insertAsync({
-			_id: "1",
-			firstName: "Steve",
-			lastName: "Minecraft",
-			email: "steve123456@gmail.com",
-			dob: "12/05/2025",
-			occupation: "Miner",
-			phone: "0432 555 222",
-			emergencyContact: "Alex",
-			employer: "The Mines",
-			workAddress: "Jungle Biome",
-			workPhone: "0122 222 123",
-			profilePicture: "img.com",
-		});
-	}
-	if ((await PropertyCollection.find().countAsync()) === 0) {
-		console.log("Seeding Property Data");
-		// Seed property statuses first
-		const statuses = [
-			{ _id: "1", name: PropertyStatus.VACANT },
-			{ _id: "2", name: PropertyStatus.OCCUPIED },
-			{ _id: "3", name: PropertyStatus.VACANT },
-		];
+  if ((await ProfileCollection.find().countAsync()) === 0) {
+    ProfileCollection.insertAsync({
+      _id: "1",
+      firstName: "Steve",
+      lastName: "Minecraft",
+      email: "steve123456@gmail.com",
+      dob: "12/05/2025",
+      occupation: "Miner",
+      phone: "0432 555 222",
+      emergencyContact: "Alex",
+      employer: "The Mines",
+      workAddress: "Jungle Biome",
+      workPhone: "0122 222 123",
+      profilePicture: "img.com",
+    });
+  }
+  if ((await PropertyCollection.find().countAsync()) === 0) {
+    console.log("Seeding Property Data");
+    // Seed property statuses first
+    const statuses = [
+      { _id: "1", name: PropertyStatus.VACANT },
+      { _id: "2", name: PropertyStatus.OCCUPIED },
+      { _id: "3", name: PropertyStatus.VACANT },
+    ];
 
-		// Add new status if it doesn't exist
-		for (const status of statuses) {
-			const existingStatus = await PropertyStatusCollection.findOneAsync({
-				_id: status._id,
-			});
-			if (!existingStatus) {
-				await PropertyStatusCollection.insertAsync(status);
-			}
-		}
+    // Add new status if it doesn't exist
+    for (const status of statuses) {
+      const existingStatus = await PropertyStatusCollection.findOneAsync({
+        _id: status._id,
+      });
+      if (!existingStatus) {
+        await PropertyStatusCollection.insertAsync(status);
+      }
+    }
 
-		await PropertyPriceCollection.insertAsync({
-			_id: "1",
-			property_id: "1",
-			price_per_month: 1500,
-			date_set: new Date(),
-		});
+    await PropertyPriceCollection.insertAsync({
+      _id: "1",
+      property_id: "1",
+      price_per_month: 1500,
+      date_set: new Date(),
+    });
 
-		await PropertyPriceCollection.insertAsync({
-			_id: "2",
-			property_id: "2",
-			price_per_month: 1300,
-			date_set: new Date(),
-		});
+    await PropertyPriceCollection.insertAsync({
+      _id: "2",
+      property_id: "2",
+      price_per_month: 1300,
+      date_set: new Date(),
+    });
 
-		await PropertyPriceCollection.insertAsync({
-			_id: "3",
-			property_id: "3",
-			price_per_month: 2000,
-			date_set: new Date(),
-		});
-
-		await PropertyListingInspectionCollection.insertAsync({
-			_id: "1",
-			starttime: new Date("2025-04-12T10:00:00Z"),
-			endtime: new Date("2025-04-13T11:00:00Z"),
-		});
-		await PropertyListingInspectionCollection.insertAsync({
-			_id: "2",
-			starttime: new Date("2025-04-14T10:00:00Z"),
-			endtime: new Date("2025-04-15T11:00:00Z"),
-		});
-
-		await PropertyListingInspectionCollection.insertAsync({
-			_id: "3",
-			starttime: new Date("2025-04-16T10:00:00Z"),
-			endtime: new Date("2025-04-17T11:00:00Z"),
-		});
-
-		await PropertyListingInspectionCollection.insertAsync({
-			_id: "4",
-			starttime: new Date("2026-04-16T10:00:00Z"),
-			endtime: new Date("2026-04-17T11:00:00Z"),
-		});
-	}
+    await PropertyPriceCollection.insertAsync({
+      _id: "3",
+      property_id: "3",
+      price_per_month: 2000,
+      date_set: new Date(),
+    });
+  }
 }
 
 async function seedListedProperties(
-	agent: ApiAgent,
-	landlord: ApiLandlord,
-	tenant: ApiTenant
+  agent: ApiAgent,
+  landlord: ApiLandlord,
+  tenant: ApiTenant
 ): Promise<void> {
-	const listedStatusId = "2";
-	const propertyStatusVacantId = "1";
-	const defaultFeatureIds = ["1", "2"];
+  const listedStatusId = "2";
+  const propertyStatusVacantId = "1";
+  const defaultFeatureIds = ["1", "2"];
 
-	// Array of 20 different image URLs for the property listings
-	const imageUrlsPool = [
-		"https://images.unsplash.com/photo-1611420890968-c87853bfa973?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1682889762731-375a6b22d794?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1677474827615-31ea6fa13efe?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1568391300292-a5a1d96b82aa?q=80&w=1928&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1566665797739-1674de7a421a?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1568495248636-6432b97bd949?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1631048501851-4aa85ffc3be8?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1582224163312-0735047647c6?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1521783988139-89397d761dce?q=80&w=1925&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1661902468735-eabf780f8ff6?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1681487208776-e308bfaa0539?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1673141390230-8b4a3c3152b1?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1661963333824-fd020faec5fc?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://plus.unsplash.com/premium_photo-1687960116506-f31f84371838?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1644847266252-14cb37a48371?q=80&w=1926&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1654291271293-ab9cb83208ce?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		"https://images.unsplash.com/photo-1610295186968-7ad29a75199e?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-	];
+  // Array of 20 different image URLs for the property listings
+  const imageUrlsPool = [
+    "https://images.unsplash.com/photo-1611420890968-c87853bfa973?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1682889762731-375a6b22d794?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1677474827615-31ea6fa13efe?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1568391300292-a5a1d96b82aa?q=80&w=1928&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1566665797739-1674de7a421a?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1568495248636-6432b97bd949?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1631048501851-4aa85ffc3be8?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1582224163312-0735047647c6?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1521783988139-89397d761dce?q=80&w=1925&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1661902468735-eabf780f8ff6?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1681487208776-e308bfaa0539?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1673141390230-8b4a3c3152b1?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1661963333824-fd020faec5fc?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1687960116506-f31f84371838?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1644847266252-14cb37a48371?q=80&w=1926&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1654291271293-ab9cb83208ce?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1610295186968-7ad29a75199e?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  ];
 
-	// Helper function to get 3 random unique URLs
-	function getRandomImageUrls(): string[] {
-		const shuffled = [...imageUrlsPool].sort(() => 0.5 - Math.random());
-		return shuffled.slice(0, 3); // Select the first 3 URLs
-	}
+  // Helper function to get 3 random unique URLs
+  function getRandomImageUrls(): string[] {
+    const shuffled = [...imageUrlsPool].sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, 3); // Select the first 3 URLs
+  }
 
-	async function seedProperties(): Promise<void> {
-		// Properties to seed
-		const properties: Array<PropertyDocument> = [
-			{
-				_id: "1",
-				streetnumber: "23",
-				streetname: "Spring St",
-				suburb: "Glen Waverley",
-				province: "VIC",
-				postcode: "3196",
-				property_status_id: "1", // Using the ID of VACANT status
-				description: "A beautiful property",
-				summary_description: "Beautiful property in a great location",
-				bathrooms: 2,
-				bedrooms: 3,
-				parking: 2,
-				property_feature_ids: ["1", "2"],
-				type: "House",
-				area: 200,
-				agent_id: globalAgent.agentId,
-				landlord_id: globalLandlord.landlordId,
-				tenant_id: globalTenant.tenantId,
-				property_coordinate_id: "1",
-			},
-			{
-				_id: "2",
-				streetnumber: "598",
-				streetname: "Heatherton Road",
-				suburb: "Noble Park",
-				province: "VIC",
-				postcode: "3174",
-				property_status_id: "2", // Using the ID of OCCUPIED status
-				description: "Modern apartment",
-				summary_description: "Modern apartment in the city center",
-				bathrooms: 1,
-				bedrooms: 2,
-				parking: 1,
-				property_feature_ids: ["2", "3"],
-				type: "Apartment",
-				area: 100,
-				agent_id: globalAgent.agentId,
-				landlord_id: globalLandlord.landlordId,
-				tenant_id: globalTenant.tenantId,
-				property_coordinate_id: "2",
-			},
-			{
-				_id: "3",
-				streetnumber: "23",
-				streetname: "Pine Rd",
-				suburb: "Clayton",
-				province: "VIC",
-				postcode: "3168",
-				property_status_id: "3", // Using the ID of UNDER_MAINTENANCE status
-				description: "Spacious house",
-				summary_description: "Spacious house with large garden",
-				bathrooms: 3,
-				bedrooms: 4,
-				parking: 2,
-				property_feature_ids: ["1", "2", "3"],
-				type: "House",
-				area: 300,
-				agent_id: globalAgent.agentId,
-				landlord_id: globalLandlord.landlordId,
-				tenant_id: globalTenant.tenantId,
-				property_coordinate_id: "3",
-			},
-			{
-				_id: "4",
-				streetnumber: "40",
-				streetname: "Reno Street",
-				suburb: "Clayton",
-				province: "VIC",
-				postcode: "3191",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Spacious 2-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
-				summary_description: "Beautiful 2-bed property in Clayton.",
-				bathrooms: 4,
-				bedrooms: 7,
-				parking: 6,
-				property_feature_ids: defaultFeatureIds,
-				type: "House",
-				area: 320,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "4",
-			},
-			{
-				_id: "5",
-				streetnumber: "50",
-				streetname: "Developer Street",
-				suburb: "Frankston",
-				province: "VIC",
-				postcode: "3188",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Spacious 3-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
-				summary_description: "Beautiful 3-bed property in Frankston.",
-				bathrooms: 2,
-				bedrooms: 3,
-				parking: 2,
-				property_feature_ids: defaultFeatureIds,
-				type: "Townhouse",
-				area: 340,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "5",
-			},
-			{
-				_id: "6",
-				streetnumber: "60",
-				streetname: "Present Court",
-				suburb: "Cranbourne",
-				province: "VIC",
-				postcode: "3111",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Spacious 4-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
-				summary_description: "Beautiful 4-bed property in Cranbourne.",
-				bathrooms: 3,
-				bedrooms: 4,
-				parking: 2,
-				property_feature_ids: defaultFeatureIds,
-				type: "House",
-				area: 360,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "6",
-			},
-			{
-				_id: "7",
-				streetnumber: "70",
-				streetname: "Central Street",
-				suburb: "Bayswater",
-				province: "VIC",
-				postcode: "4441",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Spacious 2-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
-				summary_description: "Beautiful 2-bed property in Bayswater.",
-				bathrooms: 1,
-				bedrooms: 2,
-				parking: 1,
-				property_feature_ids: defaultFeatureIds,
-				type: "Apartment",
-				area: 380,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "7",
-			},
-			{
-				_id: "8",
-				streetnumber: "80",
-				streetname: "New Street",
-				suburb: "Melbourne",
-				province: "VIC",
-				postcode: "3000",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Modern 1-bedroom apartment in the heart of the city. Close to amenities and public transport.",
-				summary_description: "Chic 1-bed apartment in Melbourne.",
-				bathrooms: 1,
-				bedrooms: 1,
-				parking: 0,
-				property_feature_ids: defaultFeatureIds,
-				type: "Apartment",
-				area: 50,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "8",
-			},
-			{
-				_id: "9",
-				streetnumber: "90",
-				streetname: "Ocean View Road",
-				suburb: "Geelong",
-				province: "VIC",
-				postcode: "3220",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Luxurious 5-bedroom house with stunning ocean views. Features a private pool and spacious garden.",
-				summary_description: "Luxury 5-bed house in Geelong.",
-				bathrooms: 4,
-				bedrooms: 5,
-				parking: 3,
-				property_feature_ids: defaultFeatureIds,
-				type: "House",
-				area: 500,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "9",
-			},
-			{
-				_id: "10",
-				streetnumber: "100",
-				streetname: "Hilltop Avenue",
-				suburb: "Ballarat",
-				province: "VIC",
-				postcode: "3350",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Charming 3-bedroom cottage with a cozy fireplace and large backyard. Perfect for families.",
-				summary_description: "Charming 3-bed cottage in Ballarat.",
-				bathrooms: 2,
-				bedrooms: 3,
-				parking: 2,
-				property_feature_ids: defaultFeatureIds,
-				type: "Cottage",
-				area: 200,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "10",
-			},
-			{
-				_id: "11",
-				streetnumber: "110",
-				streetname: "Riverbank Street",
-				suburb: "Werribee",
-				province: "VIC",
-				postcode: "3030",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Stylish 2-bedroom apartment with modern finishes and a balcony overlooking the river.",
-				summary_description: "Stylish 2-bed apartment in Werribee.",
-				bathrooms: 1,
-				bedrooms: 2,
-				parking: 1,
-				property_feature_ids: defaultFeatureIds,
-				type: "Apartment",
-				area: 120,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "11",
-			},
-			{
-				_id: "12",
-				streetnumber: "120",
-				streetname: "Forest Lane",
-				suburb: "Dandenong",
-				province: "VIC",
-				postcode: "3175",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Spacious 4-bedroom family home with a large garden and double garage. Close to schools and parks.",
-				summary_description: "Spacious 4-bed home in Dandenong.",
-				bathrooms: 3,
-				bedrooms: 4,
-				parking: 2,
-				property_feature_ids: defaultFeatureIds,
-				type: "House",
-				area: 400,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "12",
-			},
-			{
-				_id: "13",
-				streetnumber: "130",
-				streetname: "Sunset Boulevard",
-				suburb: "Hobart",
-				province: "TAS",
-				postcode: "7000",
-				property_status_id: propertyStatusVacantId,
-				description:
-					"Elegant 3-bedroom townhouse with modern amenities and a private courtyard. Ideal for professionals.",
-				summary_description: "Elegant 3-bed townhouse in Hobart.",
-				bathrooms: 2,
-				bedrooms: 3,
-				parking: 1,
-				property_feature_ids: defaultFeatureIds,
-				type: "Townhouse",
-				area: 250,
-				agent_id: agent?.agentId,
-				landlord_id: landlord?.landlordId,
-				tenant_id: tenant?.tenantId,
-				property_coordinate_id: "13",
-			},
-			// Add more properties here up to 13
-		];
+  async function seedProperties(): Promise<void> {
+    // Properties to seed
+    const properties: Array<PropertyDocument> = [
+      {
+        _id: "1",
+        streetnumber: "23",
+        streetname: "Spring St",
+        suburb: "Glen Waverley",
+        province: "VIC",
+        postcode: "3196",
+        property_status_id: "1", // Using the ID of VACANT status
+        description: "A beautiful property",
+        summary_description: "Beautiful property in a great location",
+        bathrooms: 2,
+        bedrooms: 3,
+        parking: 2,
+        property_feature_ids: ["1", "2"],
+        type: "House",
+        area: 200,
+        agent_id: globalAgent.agentId,
+        landlord_id: globalLandlord.landlordId,
+        tenant_id: globalTenant.tenantId,
+        property_coordinate_id: "1",
+      },
+      {
+        _id: "2",
+        streetnumber: "598",
+        streetname: "Heatherton Road",
+        suburb: "Noble Park",
+        province: "VIC",
+        postcode: "3174",
+        property_status_id: "2", // Using the ID of OCCUPIED status
+        description: "Modern apartment",
+        summary_description: "Modern apartment in the city center",
+        bathrooms: 1,
+        bedrooms: 2,
+        parking: 1,
+        property_feature_ids: ["2", "3"],
+        type: "Apartment",
+        area: 100,
+        agent_id: globalAgent.agentId,
+        landlord_id: globalLandlord.landlordId,
+        tenant_id: globalTenant.tenantId,
+        property_coordinate_id: "2",
+      },
+      {
+        _id: "3",
+        streetnumber: "23",
+        streetname: "Pine Rd",
+        suburb: "Clayton",
+        province: "VIC",
+        postcode: "3168",
+        property_status_id: "3", // Using the ID of UNDER_MAINTENANCE status
+        description: "Spacious house",
+        summary_description: "Spacious house with large garden",
+        bathrooms: 3,
+        bedrooms: 4,
+        parking: 2,
+        property_feature_ids: ["1", "2", "3"],
+        type: "House",
+        area: 300,
+        agent_id: globalAgent.agentId,
+        landlord_id: globalLandlord.landlordId,
+        tenant_id: globalTenant.tenantId,
+        property_coordinate_id: "3",
+      },
+      {
+        _id: "4",
+        streetnumber: "40",
+        streetname: "Reno Street",
+        suburb: "Clayton",
+        province: "VIC",
+        postcode: "3191",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Spacious 2-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
+        summary_description: "Beautiful 2-bed property in Clayton.",
+        bathrooms: 4,
+        bedrooms: 7,
+        parking: 6,
+        property_feature_ids: defaultFeatureIds,
+        type: "House",
+        area: 320,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "4",
+      },
+      {
+        _id: "5",
+        streetnumber: "50",
+        streetname: "Developer Street",
+        suburb: "Frankston",
+        province: "VIC",
+        postcode: "3188",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Spacious 3-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
+        summary_description: "Beautiful 3-bed property in Frankston.",
+        bathrooms: 2,
+        bedrooms: 3,
+        parking: 2,
+        property_feature_ids: defaultFeatureIds,
+        type: "Townhouse",
+        area: 340,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "5",
+      },
+      {
+        _id: "6",
+        streetnumber: "60",
+        streetname: "Present Court",
+        suburb: "Cranbourne",
+        province: "VIC",
+        postcode: "3111",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Spacious 4-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
+        summary_description: "Beautiful 4-bed property in Cranbourne.",
+        bathrooms: 3,
+        bedrooms: 4,
+        parking: 2,
+        property_feature_ids: defaultFeatureIds,
+        type: "House",
+        area: 360,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "6",
+      },
+      {
+        _id: "7",
+        streetnumber: "70",
+        streetname: "Central Street",
+        suburb: "Bayswater",
+        province: "VIC",
+        postcode: "4441",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Spacious 2-bedroom property in a prime location. Features modern amenities and excellent transport links. Ideal for families or professionals looking for comfort and convenience. Property includes a well-maintained garden and off-street parking.",
+        summary_description: "Beautiful 2-bed property in Bayswater.",
+        bathrooms: 1,
+        bedrooms: 2,
+        parking: 1,
+        property_feature_ids: defaultFeatureIds,
+        type: "Apartment",
+        area: 380,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "7",
+      },
+      {
+        _id: "8",
+        streetnumber: "80",
+        streetname: "New Street",
+        suburb: "Melbourne",
+        province: "VIC",
+        postcode: "3000",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Modern 1-bedroom apartment in the heart of the city. Close to amenities and public transport.",
+        summary_description: "Chic 1-bed apartment in Melbourne.",
+        bathrooms: 1,
+        bedrooms: 1,
+        parking: 0,
+        property_feature_ids: defaultFeatureIds,
+        type: "Apartment",
+        area: 50,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "8",
+      },
+      {
+        _id: "9",
+        streetnumber: "90",
+        streetname: "Ocean View Road",
+        suburb: "Geelong",
+        province: "VIC",
+        postcode: "3220",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Luxurious 5-bedroom house with stunning ocean views. Features a private pool and spacious garden.",
+        summary_description: "Luxury 5-bed house in Geelong.",
+        bathrooms: 4,
+        bedrooms: 5,
+        parking: 3,
+        property_feature_ids: defaultFeatureIds,
+        type: "House",
+        area: 500,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "9",
+      },
+      {
+        _id: "10",
+        streetnumber: "100",
+        streetname: "Hilltop Avenue",
+        suburb: "Ballarat",
+        province: "VIC",
+        postcode: "3350",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Charming 3-bedroom cottage with a cozy fireplace and large backyard. Perfect for families.",
+        summary_description: "Charming 3-bed cottage in Ballarat.",
+        bathrooms: 2,
+        bedrooms: 3,
+        parking: 2,
+        property_feature_ids: defaultFeatureIds,
+        type: "Cottage",
+        area: 200,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "10",
+      },
+      {
+        _id: "11",
+        streetnumber: "110",
+        streetname: "Riverbank Street",
+        suburb: "Werribee",
+        province: "VIC",
+        postcode: "3030",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Stylish 2-bedroom apartment with modern finishes and a balcony overlooking the river.",
+        summary_description: "Stylish 2-bed apartment in Werribee.",
+        bathrooms: 1,
+        bedrooms: 2,
+        parking: 1,
+        property_feature_ids: defaultFeatureIds,
+        type: "Apartment",
+        area: 120,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "11",
+      },
+      {
+        _id: "12",
+        streetnumber: "120",
+        streetname: "Forest Lane",
+        suburb: "Dandenong",
+        province: "VIC",
+        postcode: "3175",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Spacious 4-bedroom family home with a large garden and double garage. Close to schools and parks.",
+        summary_description: "Spacious 4-bed home in Dandenong.",
+        bathrooms: 3,
+        bedrooms: 4,
+        parking: 2,
+        property_feature_ids: defaultFeatureIds,
+        type: "House",
+        area: 400,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "12",
+      },
+      {
+        _id: "13",
+        streetnumber: "130",
+        streetname: "Sunset Boulevard",
+        suburb: "Hobart",
+        province: "TAS",
+        postcode: "7000",
+        property_status_id: propertyStatusVacantId,
+        description:
+          "Elegant 3-bedroom townhouse with modern amenities and a private courtyard. Ideal for professionals.",
+        summary_description: "Elegant 3-bed townhouse in Hobart.",
+        bathrooms: 2,
+        bedrooms: 3,
+        parking: 1,
+        property_feature_ids: defaultFeatureIds,
+        type: "Townhouse",
+        area: 250,
+        agent_id: agent?.agentId,
+        landlord_id: landlord?.landlordId,
+        tenant_id: tenant?.tenantId,
+        property_coordinate_id: "13",
+      },
+      // Add more properties here up to 13
+    ];
 
-		// Insert each property
-		for (const property of properties) {
-			const existingProperty = await PropertyCollection.findOneAsync({
-				_id: property._id,
-			});
-			if (existingProperty) {
-				console.log(
-					`[Seed] Skipped inserting existing property in PropertyCollection: ${property._id}`
-				);
-				continue;
-			}
+    // Insert each property
+    for (const property of properties) {
+      const existingProperty = await PropertyCollection.findOneAsync({
+        _id: property._id,
+      });
+      if (existingProperty) {
+        console.log(
+          `[Seed] Skipped inserting existing property in PropertyCollection: ${property._id}`
+        );
+        continue;
+      }
 
-			await PropertyCollection.insertAsync(property);
+      await PropertyCollection.insertAsync(property);
 
-			await PropertyPriceCollection.insertAsync({
-				property_id: property._id,
-				price_per_month: 1200 + parseInt(property._id) * 100,
-				date_set: new Date(),
-			});
+      await PropertyPriceCollection.insertAsync({
+        property_id: property._id,
+        price_per_month: 1200 + parseInt(property._id) * 100,
+        date_set: new Date(),
+      });
 
-			const randomImageUrls = getRandomImageUrls(); // Get 3 random image URLs
+      const randomImageUrls = getRandomImageUrls(); // Get 3 random image URLs
 
-			await ListingCollection.insertAsync({
-				property_id: property._id,
-				listing_status_id: listedStatusId, // "Listed"
-				image_urls: randomImageUrls,
-				inspection_ids: ["1", "2", "3", "4"],
-			});
+      await ListingCollection.insertAsync({
+        property_id: property._id,
+        listing_status_id: listedStatusId, // "Listed"
+        image_urls: randomImageUrls,
+        inspection_ids: ["1", "2", "3", "4"],
+      });
 
-			console.log(`[Seed] Created listed property: ${property._id}`);
-		}
-	}
+      console.log(`[Seed] Created listed property: ${property._id}`);
+    }
+  }
 
-	await seedProperties();
+  await PropertyListingInspectionCollection.insertAsync({
+    _id: "1",
+    starttime: new Date("2025-04-12T10:00:00Z"),
+    endtime: new Date("2025-04-13T11:00:00Z"),
+    tenant_ids: [tenant?.tenantId],
+  });
+  await PropertyListingInspectionCollection.insertAsync({
+    _id: "2",
+    starttime: new Date("2025-04-14T10:00:00Z"),
+    endtime: new Date("2025-04-15T11:00:00Z"),
+    tenant_ids: [""],
+  });
+
+  await PropertyListingInspectionCollection.insertAsync({
+    _id: "3",
+    starttime: new Date("2025-04-16T10:00:00Z"),
+    endtime: new Date("2025-04-17T11:00:00Z"),
+    tenant_ids: [""],
+  });
+
+  await PropertyListingInspectionCollection.insertAsync({
+    _id: "4",
+    starttime: new Date("2026-04-16T10:00:00Z"),
+    endtime: new Date("2026-04-17T11:00:00Z"),
+    tenant_ids: [""],
+  });
+
+  await seedProperties();
 }
 
 // This function is used to seed the database with initial task data
 async function tempSeedTaskData(): Promise<void> {
-	console.log("Seeding property data...");
-	if ((await TaskCollection.find().countAsync()) === 0) {
-		// Insert tasks into the TaskCollection
-		TaskCollection.insertAsync({
-			_id: "1",
-			name: "Initial listing meeting",
-			taskStatus: TaskStatus.NOTSTARTED,
-			createdDate: new Date("2025-04-12T10:00:00Z"),
-			dueDate: new Date("2025-05-19T10:00:00Z"),
-			description:
-				"Meet with the client to discuss the property listing process and gather necessary information.",
-			priority: TaskPriority.HIGH,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
+  console.log("Seeding property data...");
+  if ((await TaskCollection.find().countAsync()) === 0) {
+    // Insert tasks into the TaskCollection
+    TaskCollection.insertAsync({
+      _id: "1",
+      name: "Initial listing meeting",
+      taskStatus: TaskStatus.NOTSTARTED,
+      createdDate: new Date("2025-04-12T10:00:00Z"),
+      dueDate: new Date("2025-05-19T10:00:00Z"),
+      description:
+        "Meet with the client to discuss the property listing process and gather necessary information.",
+      priority: TaskPriority.HIGH,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
 
-		TaskCollection.insertAsync({
-			_id: "2",
-			name: "Submit Rental Application",
-			taskStatus: TaskStatus.INPROGRESS,
-			createdDate: new Date("2025-04-20T10:00:00Z"),
-			dueDate: new Date("2025-05-27T10:00:00Z"),
-			description:
-				"Check in with the client to provide updates and address any questions.",
-			priority: TaskPriority.MEDIUM,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
-		await TaskCollection.insertAsync({
-			_id: "3",
-			name: "Select a tenant",
-			taskStatus: TaskStatus.INPROGRESS,
-			createdDate: new Date("2025-04-20T10:00:00Z"),
-			dueDate: new Date("2025-05-28T10:00:00Z"),
-			description: "Review the list of agent approved candidates and pick one.",
-			priority: TaskPriority.MEDIUM,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
-		await TaskCollection.insertAsync({
-			_id: "4",
-			name: "Follow-up with client",
-			taskStatus: TaskStatus.INPROGRESS,
-			createdDate: new Date("2025-04-20T10:00:00Z"),
-			dueDate: new Date("2025-05-27T10:00:00Z"),
-			description: "Attend a property listing meeting with agent.",
-			priority: TaskPriority.MEDIUM,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
-		await TaskCollection.insertAsync({
-			_id: "5",
-			name: "Property annual inspection",
-			taskStatus: TaskStatus.INPROGRESS,
-			createdDate: new Date("2025-04-20T10:00:00Z"),
-			dueDate: new Date("2025-05-27T10:00:00Z"),
-			description: "Attend the annual inspection.",
-			priority: TaskPriority.MEDIUM,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
-		await TaskCollection.insertAsync({
-			_id: "6",
-			name: "Sign rental agreement",
-			taskStatus: TaskStatus.INPROGRESS,
-			createdDate: new Date("2025-04-20T10:00:00Z"),
-			dueDate: new Date("2025-05-27T10:00:00Z"),
-			description:
-				"Sign the rental agreement which has had the rent increased by 5%.",
-			priority: TaskPriority.MEDIUM,
-			taskPropertyAddress: "",
-			taskPropertyId: "",
-		});
+    TaskCollection.insertAsync({
+      _id: "2",
+      name: "Submit Rental Application",
+      taskStatus: TaskStatus.INPROGRESS,
+      createdDate: new Date("2025-04-20T10:00:00Z"),
+      dueDate: new Date("2025-05-27T10:00:00Z"),
+      description:
+        "Check in with the client to provide updates and address any questions.",
+      priority: TaskPriority.MEDIUM,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
+    await TaskCollection.insertAsync({
+      _id: "3",
+      name: "Select a tenant",
+      taskStatus: TaskStatus.INPROGRESS,
+      createdDate: new Date("2025-04-20T10:00:00Z"),
+      dueDate: new Date("2025-05-28T10:00:00Z"),
+      description: "Review the list of agent approved candidates and pick one.",
+      priority: TaskPriority.MEDIUM,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
+    await TaskCollection.insertAsync({
+      _id: "4",
+      name: "Follow-up with client",
+      taskStatus: TaskStatus.INPROGRESS,
+      createdDate: new Date("2025-04-20T10:00:00Z"),
+      dueDate: new Date("2025-05-27T10:00:00Z"),
+      description: "Attend a property listing meeting with agent.",
+      priority: TaskPriority.MEDIUM,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
+    await TaskCollection.insertAsync({
+      _id: "5",
+      name: "Property annual inspection",
+      taskStatus: TaskStatus.INPROGRESS,
+      createdDate: new Date("2025-04-20T10:00:00Z"),
+      dueDate: new Date("2025-05-27T10:00:00Z"),
+      description: "Attend the annual inspection.",
+      priority: TaskPriority.MEDIUM,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
+    await TaskCollection.insertAsync({
+      _id: "6",
+      name: "Sign rental agreement",
+      taskStatus: TaskStatus.INPROGRESS,
+      createdDate: new Date("2025-04-20T10:00:00Z"),
+      dueDate: new Date("2025-05-27T10:00:00Z"),
+      description:
+        "Sign the rental agreement which has had the rent increased by 5%.",
+      priority: TaskPriority.MEDIUM,
+      taskPropertyAddress: "",
+      taskPropertyId: "",
+    });
 
-		console.log("Tasks seeded successfully.");
-	}
+    console.log("Tasks seeded successfully.");
+  }
 
-	// Update the task_ids field for Agent, Tenant, and Landlord
-	if (globalAgent) {
-		await AgentCollection.updateAsync(
-			{ _id: globalAgent.agentId }, // Find the agent by ID
-			{ $set: { task_ids: ["1", "2"] } } // Assign task IDs
-		);
-		console.log("Assigned tasks to Agent:", globalAgent.agentId);
-	}
+  // Update the task_ids field for Agent, Tenant, and Landlord
+  if (globalAgent) {
+    await AgentCollection.updateAsync(
+      { _id: globalAgent.agentId }, // Find the agent by ID
+      { $set: { task_ids: ["1", "2"] } } // Assign task IDs
+    );
+    console.log("Assigned tasks to Agent:", globalAgent.agentId);
+  }
 
-	if (globalTenant) {
-		await TenantCollection.updateAsync(
-			{ _id: globalTenant.tenantId }, // Find the tenant by ID
-			{ $set: { task_ids: ["5", "6"] } } // Assign task IDs
-		);
-		console.log("Assigned tasks to Tenant:", globalTenant.tenantId);
-	}
+  if (globalTenant) {
+    await TenantCollection.updateAsync(
+      { _id: globalTenant.tenantId }, // Find the tenant by ID
+      { $set: { task_ids: ["5", "6"] } } // Assign task IDs
+    );
+    console.log("Assigned tasks to Tenant:", globalTenant.tenantId);
+  }
 
-	if (globalLandlord) {
-		await LandlordCollection.updateAsync(
-			{ _id: globalLandlord.landlordId }, // Find the landlord by ID
-			{ $set: { task_ids: ["3", "4"] } } // Assign task IDs
-		);
-		console.log("Assigned tasks to Landlord:", globalLandlord.landlordId);
-	}
+  if (globalLandlord) {
+    await LandlordCollection.updateAsync(
+      { _id: globalLandlord.landlordId }, // Find the landlord by ID
+      { $set: { task_ids: ["3", "4"] } } // Assign task IDs
+    );
+    console.log("Assigned tasks to Landlord:", globalLandlord.landlordId);
+  }
 }
 
 async function permSeedListingStatusData(): Promise<void> {
-	if ((await ListingStatusCollection.find().countAsync()) === 0) {
-		console.log("Seeding listing status data...");
-		await ListingStatusCollection.insertAsync({
-			_id: "1",
-			name: ListingStatus.DRAFT,
-		});
-		await ListingStatusCollection.insertAsync({
-			_id: "2",
-			name: ListingStatus.LISTED,
-		});
-		await ListingStatusCollection.insertAsync({
-			_id: "3",
-			name: ListingStatus.CLOSED,
-		});
-		await ListingStatusCollection.insertAsync({
-			_id: "4",
-			name: ListingStatus.TENANT_APPROVAL,
-		});
-	}
+  if ((await ListingStatusCollection.find().countAsync()) === 0) {
+    console.log("Seeding listing status data...");
+    await ListingStatusCollection.insertAsync({
+      _id: "1",
+      name: ListingStatus.DRAFT,
+    });
+    await ListingStatusCollection.insertAsync({
+      _id: "2",
+      name: ListingStatus.LISTED,
+    });
+    await ListingStatusCollection.insertAsync({
+      _id: "3",
+      name: ListingStatus.CLOSED,
+    });
+    await ListingStatusCollection.insertAsync({
+      _id: "4",
+      name: ListingStatus.TENANT_APPROVAL,
+    });
+  }
 }
 
 async function seedLeaseAgreements(agent: ApiAgent): Promise<void> {
-	if ((await LeaseAgreementCollection.find().countAsync()) === 0) {
-		console.log("Seeding lease agreement data...");
+  if ((await LeaseAgreementCollection.find().countAsync()) === 0) {
+    console.log("Seeding lease agreement data...");
 
-		// Create a sample lease agreement for Amanda (the agent)
-		// Create multiple sample lease agreements for Amanda (the agent)
-		await LeaseAgreementCollection.insertAsync({
-			_id: "lease_1",
-			propertyId: "1", // 23 Spring St, Glen Waverley
-			agentId: agent?.agentId || "",
-			uploadedDate: new Date(),
-			validUntil: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-			documentUrl: "https://example.com/sample-lease-agreement.pdf",
-			tenantName: "Todd Toolgate",
-			title: "Leaase 1",
-		});
+    // Create a sample lease agreement for Amanda (the agent)
+    // Create multiple sample lease agreements for Amanda (the agent)
+    await LeaseAgreementCollection.insertAsync({
+      _id: "lease_1",
+      propertyId: "1", // 23 Spring St, Glen Waverley
+      agentId: agent?.agentId || "",
+      uploadedDate: new Date(),
+      validUntil: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      documentUrl: "https://example.com/sample-lease-agreement.pdf",
+      tenantName: "Todd Toolgate",
+      title: "Leaase 1",
+    });
 
-		await LeaseAgreementCollection.insertAsync({
-			_id: "lease_2",
-			propertyId: "2", // 598 Heatherton Road, Noble Park
-			agentId: agent?.agentId || "",
-			uploadedDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 1 week ago
-			validUntil: new Date(Date.now() + 300 * 24 * 60 * 60 * 1000), // 10 months from now
-			documentUrl: "https://example.com/another-lease-agreement.pdf",
-			tenantName: "Sarah Johnson",
-			title: "Leaase 2",
-		});
+    await LeaseAgreementCollection.insertAsync({
+      _id: "lease_2",
+      propertyId: "2", // 598 Heatherton Road, Noble Park
+      agentId: agent?.agentId || "",
+      uploadedDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 1 week ago
+      validUntil: new Date(Date.now() + 300 * 24 * 60 * 60 * 1000), // 10 months from now
+      documentUrl: "https://example.com/another-lease-agreement.pdf",
+      tenantName: "Sarah Johnson",
+      title: "Leaase 2",
+    });
 
-		await LeaseAgreementCollection.insertAsync({
-			_id: "lease_3",
-			propertyId: "3", // 23 Pine Rd, Clayton
-			agentId: agent?.agentId || "",
-			uploadedDate: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000), // 2 weeks ago
-			validUntil: new Date(Date.now() + 350 * 24 * 60 * 60 * 1000), // 11.5 months from now
-			documentUrl: "https://example.com/third-lease-agreement.pdf",
-			tenantName: "Mike Chen",
-			title: "Leaase 3",
-		});
+    await LeaseAgreementCollection.insertAsync({
+      _id: "lease_3",
+      propertyId: "3", // 23 Pine Rd, Clayton
+      agentId: agent?.agentId || "",
+      uploadedDate: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000), // 2 weeks ago
+      validUntil: new Date(Date.now() + 350 * 24 * 60 * 60 * 1000), // 11.5 months from now
+      documentUrl: "https://example.com/third-lease-agreement.pdf",
+      tenantName: "Mike Chen",
+      title: "Leaase 3",
+    });
 
-		// Add a lease agreement specifically for Todd Toolgate (tenant)
-		await LeaseAgreementCollection.insertAsync({
-			_id: "lease_4",
-			propertyId: "1", // 23 Spring St, Glen Waverley (same as lease_1 but for tenant view)
-			agentId: agent?.agentId || "",
-			uploadedDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
-			validUntil: new Date(Date.now() + 200 * 24 * 60 * 60 * 1000), // 6.5 months from now
-			documentUrl: "https://example.com/todd-toolgate-lease.pdf",
-			tenantName: "Todd Toolgate",
-			title: "Leaase 4",
-		});
+    // Add a lease agreement specifically for Todd Toolgate (tenant)
+    await LeaseAgreementCollection.insertAsync({
+      _id: "lease_4",
+      propertyId: "1", // 23 Spring St, Glen Waverley (same as lease_1 but for tenant view)
+      agentId: agent?.agentId || "",
+      uploadedDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
+      validUntil: new Date(Date.now() + 200 * 24 * 60 * 60 * 1000), // 6.5 months from now
+      documentUrl: "https://example.com/todd-toolgate-lease.pdf",
+      tenantName: "Todd Toolgate",
+      title: "Leaase 4",
+    });
 
-		console.log("Lease agreement seeded successfully.");
-	}
+    console.log("Lease agreement seeded successfully.");
+  }
 }
 
 async function removeAllCollections(): Promise<void> {
-	console.log("Removing all collections...");
-	await Meteor.users.removeAsync({});
-	await AgentCollection.removeAsync({});
-	await LandlordCollection.removeAsync({});
-	await TenantCollection.removeAsync({});
-	await ProfileCollection.removeAsync({});
-	await UserAccountCollection.removeAsync({});
-	await PropertyCollection.removeAsync({});
-	await PropertyFeatureCollection.removeAsync({});
-	await PropertyPriceCollection.removeAsync({});
-	await PropertyStatusCollection.removeAsync({});
-	await PropertyCoordinatesCollection.removeAsync({});
-	await PropertyListingInspectionCollection.removeAsync({});
-	await ListingCollection.removeAsync({});
-	await ListingStatusCollection.removeAsync({});
-	await TaskCollection.removeAsync({});
-	await LeaseAgreementCollection.removeAsync({});
+  console.log("Removing all collections...");
+  await Meteor.users.removeAsync({});
+  await AgentCollection.removeAsync({});
+  await LandlordCollection.removeAsync({});
+  await TenantCollection.removeAsync({});
+  await ProfileCollection.removeAsync({});
+  await UserAccountCollection.removeAsync({});
+  await PropertyCollection.removeAsync({});
+  await PropertyFeatureCollection.removeAsync({});
+  await PropertyPriceCollection.removeAsync({});
+  await PropertyStatusCollection.removeAsync({});
+  await PropertyCoordinatesCollection.removeAsync({});
+  await PropertyListingInspectionCollection.removeAsync({});
+  await ListingCollection.removeAsync({});
+  await ListingStatusCollection.removeAsync({});
+  await TaskCollection.removeAsync({});
+  await LeaseAgreementCollection.removeAsync({});
 }
 
 async function removeTenantApplicationsData(): Promise<void> {
-	console.log("Removing tenant applications data...");
-	await TenantApplicationCollection.removeAsync({});
-	console.log("Tenant applications removed successfully.");
+  console.log("Removing tenant applications data...");
+  await TenantApplicationCollection.removeAsync({});
+  console.log("Tenant applications removed successfully.");
 }
 async function permSeedPropertyFeaturesData(): Promise<void> {
-	const features = [
-		{ _id: "1", name: "Washing Machine" },
-		{ _id: "2", name: "Hair Dryer" },
-		{ _id: "3", name: "Garden" },
-		{ _id: "4", name: "Air Conditioning" },
-		{ _id: "5", name: "Heater" },
-		{ _id: "6", name: "Garage" },
-		{ _id: "7", name: "Pool" },
-	];
+  const features = [
+    { _id: "1", name: "Washing Machine" },
+    { _id: "2", name: "Hair Dryer" },
+    { _id: "3", name: "Garden" },
+    { _id: "4", name: "Air Conditioning" },
+    { _id: "5", name: "Heater" },
+    { _id: "6", name: "Garage" },
+    { _id: "7", name: "Pool" },
+  ];
 
-	for (const feature of features) {
-		const existing = await PropertyFeatureCollection.findOneAsync({
-			_id: feature._id,
-		});
-		if (!existing) {
-			await PropertyFeatureCollection.insertAsync(feature);
-			console.log(`[Seed] Inserted feature: ${feature.name}`);
-		}
-	}
+  for (const feature of features) {
+    const existing = await PropertyFeatureCollection.findOneAsync({
+      _id: feature._id,
+    });
+    if (!existing) {
+      await PropertyFeatureCollection.insertAsync(feature);
+      console.log(`[Seed] Inserted feature: ${feature.name}`);
+    }
+  }
 }

--- a/app/server/methods/property-listing/listing-methods.ts
+++ b/app/server/methods/property-listing/listing-methods.ts
@@ -43,9 +43,8 @@ const submitDraftListing = {
   ): Promise<{ success: boolean; propertyId: string }> => {
     try {
       // Find the listing for this property
-      const listing = await getListingDocumentAssociatedWithProperty(
-        propertyId
-      );
+      const listing =
+        await getListingDocumentAssociatedWithProperty(propertyId);
 
       if (!listing) {
         throw meteorWrappedInvalidDataError(
@@ -98,7 +97,8 @@ const getAllListedListings = {
     limit: number = 3
   ): Promise<ApiListing[]> => {
     const listedStatus = ListingStatus.LISTED;
-    const listedStatusDocument = await getListingStatusDocumentByName(listedStatus);
+    const listedStatusDocument =
+      await getListingStatusDocumentByName(listedStatus);
 
     if (!listedStatusDocument) {
       throw meteorWrappedInvalidDataError(
@@ -148,9 +148,10 @@ async function mapListingDocumentToListingDTO(
   let propertyListingInspections: PropertyListingInspectionDocument[] = [];
 
   if (listing.inspection_ids.length > 0) {
-    propertyListingInspections = await getPropertyListingInspectionDocumentsMatchingIds(
-      listing.inspection_ids
-    );
+    propertyListingInspections =
+      await getPropertyListingInspectionDocumentsMatchingIds(
+        listing.inspection_ids
+      );
   }
 
   const listingStatusDocument = await getListingStatusDocumentById(
@@ -167,10 +168,12 @@ async function mapListingDocumentToListingDTO(
     property_id: listing.property_id,
     image_urls: listing.image_urls,
     listing_status: listingStatusDocument.name,
-    propertyListingInspections: propertyListingInspections.map((inspection) => ({
-      start_time: inspection.starttime,
-      end_time: inspection.endtime,
-    })),
+    propertyListingInspections: propertyListingInspections.map(
+      (inspection) => ({
+        start_time: inspection.starttime,
+        end_time: inspection.endtime,
+      })
+    ),
   };
 }
 
@@ -264,7 +267,8 @@ const updatePropertyListingImages = {
   ): Promise<{ success: boolean; propertyId: string }> => {
     try {
       // Find the listing for this property
-      const listing = await getListingDocumentAssociatedWithProperty(propertyId);
+      const listing =
+        await getListingDocumentAssociatedWithProperty(propertyId);
 
       if (!listing) {
         throw meteorWrappedInvalidDataError(
@@ -300,6 +304,32 @@ const updatePropertyListingImages = {
   },
 };
 
+export async function addTenantToInspection(
+  inspectionId: string,
+  tenantId: string
+): Promise<PropertyListingInspectionDocument> {
+  // Fetch the inspection document
+  const inspection = await PropertyListingInspectionCollection.findOne({
+    _id: inspectionId,
+  });
+
+  if (!inspection) throw new Error("Inspection not found");
+
+  // Add tenantId if it’s not already there
+  if (!inspection.tenant_ids.includes(tenantId)) {
+    inspection.tenant_ids.push(tenantId);
+    await PropertyListingInspectionCollection.updateAsync(
+      { _id: inspectionId },
+      { $set: { tenant_ids: inspection.tenant_ids } }
+    );
+  }
+  const updatedInspection = await PropertyListingInspectionCollection.findOne({
+    _id: inspectionId,
+  });
+  if (!updatedInspection) throw new Error("Inspection not found after update");
+
+  return updatedInspection;
+}
 Meteor.methods({
   ...getListingForProperty,
   ...insertDraftListingDocumentForProperty,

--- a/app/server/methods/property-listing/listing-methods.ts
+++ b/app/server/methods/property-listing/listing-methods.ts
@@ -1,3 +1,4 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
 import {
   PropertyListingInspectionCollection,
   ListingCollection,
@@ -329,7 +330,22 @@ export async function addTenantToInspection(
   if (!updatedInspection) throw new Error("Inspection not found after update");
 
   return updatedInspection;
-}
+};
+
+export const bookPropertyInspectionAsync = createAsyncThunk(
+  "propertyListing/bookPropertyInspection",
+  async ({
+    inspectionId,
+    tenantId,
+  }: {
+    inspectionId: string;
+    tenantId: string;
+  }): Promise<PropertyListingInspectionDocument> => {
+    const updatedInspection = await addTenantToInspection(inspectionId, tenantId);
+    return updatedInspection;
+  }
+);
+
 Meteor.methods({
   ...getListingForProperty,
   ...insertDraftListingDocumentForProperty,

--- a/app/shared/api-models/property-listing/ApiListing.ts
+++ b/app/shared/api-models/property-listing/ApiListing.ts
@@ -6,5 +6,6 @@ export type ApiListing = {
   propertyListingInspections: {
     start_time: Date;
     end_time: Date;
+    tenant_ids: string[];
   }[];
 };

--- a/app/shared/meteor-method-identifier.ts
+++ b/app/shared/meteor-method-identifier.ts
@@ -22,6 +22,7 @@ export enum MeteorMethodIdentifier {
 	LISTING_UPDATE_IMAGES = "listings.updateImages", // Update images of a draft listing
 	INSERT_PROPERTY_LISTING = "listings.insertProperty",
 	INSERT_PROPERTY_LISTING_INSPECTION = "inspections.insert",
+	ADD_TENANT_TO_INSPECTION = "inspection.addTenant",
 	USER_REGISTER = "user.register",
 	USER_ACCOUNT_INSERT = "users.insert",
 	USER_ACCOUNT_GET = "users.getOne",


### PR DESCRIPTION
In this PR, I am fixing a bug we carried over from M3 - which was when clicking on the 'book' button, we were seeing that stay for the entire website, not on a per tenant basis 

Now 
A tenant can click 'book' and they are registered for that inspection 
This will then feed into the 'apply' disable-enable status --> As a tenant can only apply if they have been to an inspection for the given property.

<img width="1171" height="932" alt="image" src="https://github.com/user-attachments/assets/3e362393-15ac-4aea-85b1-7140fc232220" />
