### PR TITLE
86d0b26r3: Change condition to show Contact Agent and Apply Button based on user ROLE

### DIFF
--- a/app/client/ui-modules/common/property-components/ContactAgentButton.tsx
+++ b/app/client/ui-modules/common/property-components/ContactAgentButton.tsx
@@ -23,7 +23,7 @@ export function ContactAgentButton({
   };
   return (
     <ThemedButton
-      variant={ThemedButtonVariant.PRIMARY}
+      variant={ThemedButtonVariant.SECONDARY}
       onClick={handleClick}
       className={twMerge("w-[128px]", className)}
     >

--- a/app/client/ui-modules/property-listing-page/PropertyListingPage.tsx
+++ b/app/client/ui-modules/property-listing-page/PropertyListingPage.tsx
@@ -143,7 +143,7 @@ export function PropertyListingPage({
           shouldDisplaySubmitDraftButton={state.shouldDisplaySubmitDraftButton}
           shouldDisplayReviewTenantButton={
             state.shouldDisplayReviewTenantButton
-           && (role === Role.LANDLORD || role === Role.AGENT)}
+            && (role === Role.LANDLORD || role === Role.AGENT)}
           shouldDisplayEditListingButton={state.shouldDisplayEditListingButton}
           authUser={authUser}
           profileData={profileData}
@@ -622,14 +622,19 @@ function ListingHero({
           className="w-full mb-8"
         />
         <div className="flex">
-          <ApplyButton
-            onClick={onApply}
-            isLoading={isApplying}
-            userRole={userRole}
-            hasApplied={hasApplied}
-            className="mr-4"
-          />
-          <ContactAgentButton propertyId={propertyId} />
+          {(!userRole || userRole === Role.TENANT) && (
+            <ApplyButton
+              onClick={onApply}
+              isLoading={isApplying}
+              userRole={userRole}
+              hasApplied={hasApplied}
+              className="mr-4"
+            />
+          )}
+
+          {userRole === Role.TENANT && (
+            <ContactAgentButton propertyId={propertyId} />
+          )}
         </div>
       </div>
     </div>

--- a/app/client/ui-modules/property-listing-page/components/ApplyButton.tsx
+++ b/app/client/ui-modules/property-listing-page/components/ApplyButton.tsx
@@ -29,7 +29,12 @@ export function ApplyButton({
   } else if (userRole === Role.LANDLORD) {
     buttonText = "Landlords cannot apply";
     isDisabled = true;
-  } else if (hasApplied) {
+  } 
+  else if (!userRole){
+    buttonText = "Sign In to Apply";
+    isDisabled = true;
+  }
+  else if (hasApplied) {
     buttonText = "Already Applied";
     isDisabled = true;
   } else if (isLoading) {
@@ -38,11 +43,11 @@ export function ApplyButton({
 
   return (
     <ThemedButton
-      variant={ThemedButtonVariant.SECONDARY}
+      variant={ThemedButtonVariant.PRIMARY}
       onClick={isDisabled ? () => {} : onClick}
       className={twMerge(
         "w-[128px]",
-        isDisabled && hasApplied ? "opacity-50 cursor-not-allowed" : "",
+        isDisabled || hasApplied ? "opacity-50 cursor-not-allowed" : "",
         className
       )}
     >


### PR DESCRIPTION
'Contact Agent' now only appears if user is logged in as a TENANT
'Apply Button' now only appears if user is a GUEST or logged in as a TENANT (Note: Apply Button has the text "Sign in to apply" for guests)
Apply Button no longer appears if user is logged in as a LANDLORD OR AGENT

Guest:
<img width="1426" height="412" alt="image" src="https://github.com/user-attachments/assets/b065a61c-9fc0-429e-b54b-c2e9bd3155b5" />

Agent:
<img width="1418" height="411" alt="image" src="https://github.com/user-attachments/assets/1ebe8632-91a1-46e8-9c07-0d1dba54a971" />

Tenant:
<img width="1424" height="411" alt="image" src="https://github.com/user-attachments/assets/66bc191c-78fc-440e-8b52-b02fb00fdc54" />

Landlord:
<img width="1418" height="409" alt="image" src="https://github.com/user-attachments/assets/f27c297e-009d-4465-a1fc-bdc538214549" />


