### PR TITLE
86d0czamg: Remove button on calendar page

### DIFF
--- a/app/client/ui-modules/role-dashboard/agent-dashboard/pages/AgentCalendar.tsx
+++ b/app/client/ui-modules/role-dashboard/agent-dashboard/pages/AgentCalendar.tsx
@@ -154,7 +154,7 @@ export function AgentCalendar(): React.JSX.Element {
                 <Button onClick={handleOpenModal}>Add Task</Button>
               </div>
             </div>
-            <UpcomingTasks tasks={tasks} />
+            <UpcomingTasks tasks={tasks} showViewAllButton={false} />
           </div>
         </div>
       </div>

--- a/app/client/ui-modules/role-dashboard/components/UpcomingTask.tsx
+++ b/app/client/ui-modules/role-dashboard/components/UpcomingTask.tsx
@@ -12,6 +12,7 @@ import { UserAccount } from "/app/client/library-modules/domain-models/user/User
 export function UpcomingTasks(props: {
   tasks: Task[];
   currentUser?: UserAccount | null;
+  showViewAllButton?: boolean; // Default is true
 }): React.JSX.Element {
   const navigate = useNavigate();
 
@@ -63,11 +64,13 @@ export function UpcomingTasks(props: {
           <div className="text-center text-gray-500">No upcoming tasks</div>
         )}
       </div>
-      <div className="mt-4">
-        <ViewAllButton onClick={handleViewAllTasks}>
-          View All Tasks
-        </ViewAllButton>
-      </div>
+      {(props.showViewAllButton ?? true) && (
+        <div className="mt-4">
+          <ViewAllButton onClick={handleViewAllTasks}>
+            View All Tasks
+          </ViewAllButton>
+        </div>
+      )}
     </CardWidget>
   );
 }

--- a/app/client/ui-modules/role-dashboard/landlord-dashboard/pages/LandlordCalendar.tsx
+++ b/app/client/ui-modules/role-dashboard/landlord-dashboard/pages/LandlordCalendar.tsx
@@ -156,7 +156,7 @@ export function LandlordCalendar(): React.JSX.Element {
                 <Button onClick={handleOpenModal}>Add Task</Button>
               </div>
             </div>
-            <UpcomingTasks tasks={tasks} />
+            <UpcomingTasks tasks={tasks} showViewAllButton={false} />
           </div>
         </div>
       </div>

--- a/app/client/ui-modules/role-dashboard/tenant-dashboard/pages/TenantCalendar.tsx
+++ b/app/client/ui-modules/role-dashboard/tenant-dashboard/pages/TenantCalendar.tsx
@@ -127,7 +127,7 @@ export function TenantCalendar(): React.JSX.Element {
             </div>
 
             {/* Right Section: Upcoming Tasks */}
-            <UpcomingTasks tasks={tasks} />
+            <UpcomingTasks tasks={tasks} showViewAllButton={false} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Summary of changes
* resolves issue #139 
* "View All Tasks" button only shows on dashboard, not on calendar page for all roles

### Screenshot
On the calendar page:
<img width="788" height="1110" alt="image" src="https://github.com/user-attachments/assets/f95e6ce4-4bdc-4e4e-9c3d-7b0942b32381" />
