### PR TITLE
86d0h9vnp: add clickable functionality on landlord properties on dashboard

### DIFF
--- a/app/client/ui-modules/role-dashboard/landlord-dashboard/components/MyProperties.tsx
+++ b/app/client/ui-modules/role-dashboard/landlord-dashboard/components/MyProperties.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { useNavigate } from "react-router";
 import { Button } from "../../../theming-shadcn/Button";
 import { CardWidget } from "../../../common/CardWidget";
-import { Property } from "/app/client/library-modules/domain-models/property/Property";
+import { PropertyWithListingDataAndNames } from "../state/landlord-properties-slice";
 import { PropertyStatus } from "/app/shared/api-models/property/PropertyStatus";
 import { NavigationPath } from "/app/client/navigation";
 import { ViewAllButton } from "../../components/ViewAllButton";
 
 interface PropertyOverviewProps {
-  properties: Property[];
+  properties: PropertyWithListingDataAndNames[];
 }
 
 export function MyProperties({
@@ -18,6 +18,13 @@ export function MyProperties({
 
   const handleViewAllProperties = () => {
     navigate(NavigationPath.LandlordProperties);
+  };
+
+  const handlePropertyClick = (property: PropertyWithListingDataAndNames) => {
+    const url = `${NavigationPath.LandlordPropertyDetail}?propertyId=${property.propertyId}`;
+    navigate(url, {
+      state: { property }
+    });
   };
   return (
     <CardWidget
@@ -61,7 +68,11 @@ export function MyProperties({
             </thead>
             <tbody className="divide-y divide-gray-200">
               {properties.map((property, index) => (
-                <tr key={index} className="transition-colors hover:bg-gray-50">
+                <tr 
+                  key={index} 
+                  className="transition-colors hover:bg-gray-50 cursor-pointer"
+                  onClick={() => handlePropertyClick(property)}
+                >
                   <td className="px-6 py-4 text-sm">{`${property.streetnumber} ${property.streetname}`}</td>
                   <td className="px-6 py-4">
                     <span

--- a/app/client/ui-modules/role-dashboard/landlord-dashboard/pages/LandlordDashboard.tsx
+++ b/app/client/ui-modules/role-dashboard/landlord-dashboard/pages/LandlordDashboard.tsx
@@ -6,20 +6,24 @@ import { UpcomingTasks } from "../../components/UpcomingTask";
 import { MyProperties } from "../components/MyProperties";
 import {
   selectTasks,
-  selectProperties,
   fetchLandlordDetails,
   selectLandlordDashboard,
 } from "../state/landlord-dashboard-slice";
+import {
+  selectLandlordProperties,
+  fetchLandlordProperties
+} from "../state/landlord-properties-slice";
 
 export function LandlordDashboard(): React.JSX.Element {
   const dispatch = useAppDispatch();
-  const properties = useAppSelector(selectProperties);
+  const properties = useAppSelector(selectLandlordProperties);
   const tasks = useAppSelector(selectTasks);
   const dashboardData = useAppSelector(selectLandlordDashboard);
   const currentUser = useAppSelector((state) => state.currentUser.authUser);
   useEffect(() => {
     if (currentUser?.userId) {
       dispatch(fetchLandlordDetails());
+      dispatch(fetchLandlordProperties(currentUser.userId));
     } else {
       console.warn("No user ID found. Please log in to view the dashboard.");
     }


### PR DESCRIPTION
### Summary of changes
The properties shown on the landlord's dashboard can be clicked and takes the user to property page.

<img width="638" height="420" alt="image" src="https://github.com/user-attachments/assets/41e64dcd-2667-4fdf-90ee-aea2bf62ac1a" />
